### PR TITLE
[CHORE] Api Docs 세팅 및 BaseTime 세팅

### DIFF
--- a/.github/workflows/owori-ci.yml
+++ b/.github/workflows/owori-ci.yml
@@ -9,7 +9,7 @@ on:
 defaults:
   run:
     shell: bash
-    working-directory: ./backend
+    working-directory: .
 jobs:
   backend-test:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.13'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'com.google.cloud.tools.jib' version '3.2.1'
+	id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 jib {
@@ -45,8 +46,35 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testCompileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'com.h2database:h2:1.4.200'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+}
+
+ext {
+	snippetsDir = file('build/generated-snippets')
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from("${asciidoctor.outputDir}/html5")
+	into 'static/docs'
+}
+
+asciidoctor {
+	inputs.dir snippetsDir
+	dependsOn test
 }
 
 tasks.named('test') {
+	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+configurations {
+	asciidoctorExtensions
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
 }

--- a/src/docs/auth.adoc
+++ b/src/docs/auth.adoc
@@ -1,0 +1,9 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+
+== Auth
+=== 리프레시 토큰 갱신
+operation::refresh jwt token[snippets='http-request,http-response']

--- a/src/docs/index.adoc
+++ b/src/docs/index.adoc
@@ -1,0 +1,11 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+= Owori API Docs
+오월이
+
+include::auth.adoc[]

--- a/src/main/java/com/owori/OworiApplication.java
+++ b/src/main/java/com/owori/OworiApplication.java
@@ -2,12 +2,12 @@ package com.owori;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OworiApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(OworiApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/owori/config/security/jwt/JwtToken.java
+++ b/src/main/java/com/owori/config/security/jwt/JwtToken.java
@@ -1,0 +1,13 @@
+package com.owori.config.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class JwtToken {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/owori/domain/member/controller/AuthController.java
+++ b/src/main/java/com/owori/domain/member/controller/AuthController.java
@@ -19,7 +19,7 @@ public class AuthController {
      * Jwt 검증 및 재발급 컨트롤러입니다.
      * 헤더로 리프레시 토큰과 액세스 토큰을 받아와 검증하고 액세스 토큰의 검증에 실패해도 리프레시 토큰이 성공하면 재발급합니다.
      * @param refreshToken 리프레시 토큰입니다.
-     * @param accessToken 액세스 토큰입니다. 리프레시 토큰보다 긴 유효기간을 갖습니다.
+     * @param accessToken 액세스 토큰입니다. 리프레시 토큰보다 짧은 유효기간을 갖습니다.
      * @return JwtToken은 액세스 토큰과 리프레시 토큰입니다. 상황에 따라 새롭게 발급된 토큰일 수 있습니다.
      */
     @GetMapping("/refresh")

--- a/src/main/java/com/owori/domain/member/controller/AuthController.java
+++ b/src/main/java/com/owori/domain/member/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.owori.domain.member.controller;
+
+import com.owori.config.security.jwt.JwtToken;
+import com.owori.domain.member.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    /**
+     * Jwt 검증 및 재발급 컨트롤러입니다.
+     * 헤더로 리프레시 토큰과 액세스 토큰을 받아와 검증하고 액세스 토큰의 검증에 실패해도 리프레시 토큰이 성공하면 재발급합니다.
+     * @param refreshToken 리프레시 토큰입니다.
+     * @param accessToken 액세스 토큰입니다. 리프레시 토큰보다 긴 유효기간을 갖습니다.
+     * @return JwtToken은 액세스 토큰과 리프레시 토큰입니다. 상황에 따라 새롭게 발급된 토큰일 수 있습니다.
+     */
+    @GetMapping("/refresh")
+    public ResponseEntity<JwtToken> authorize(
+            @RequestHeader String refreshToken,
+            @RequestHeader String accessToken) {
+        return ResponseEntity.ok(authService.refreshToken(refreshToken, accessToken));
+    }
+}

--- a/src/main/java/com/owori/domain/member/controller/MemberController.java
+++ b/src/main/java/com/owori/domain/member/controller/MemberController.java
@@ -1,0 +1,11 @@
+package com.owori.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+}

--- a/src/main/java/com/owori/domain/member/entity/AuthProvider.java
+++ b/src/main/java/com/owori/domain/member/entity/AuthProvider.java
@@ -1,0 +1,10 @@
+package com.owori.domain.member.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AuthProvider {
+    APPLE("애플"), KAKAO("카카오");
+
+    private final String toKorean;
+}

--- a/src/main/java/com/owori/domain/member/entity/Color.java
+++ b/src/main/java/com/owori/domain/member/entity/Color.java
@@ -1,0 +1,10 @@
+package com.owori.domain.member.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Color {
+    RED("빨간색"), ORANGE("주황색"), YELLOW("노란색"), GREEN("초록색"), BLUE("파란색"); // todo 색상 목록 확인 필요
+
+    private final String toKorean;
+}

--- a/src/main/java/com/owori/domain/member/entity/Member.java
+++ b/src/main/java/com/owori/domain/member/entity/Member.java
@@ -1,0 +1,58 @@
+package com.owori.domain.member.entity;
+
+import com.owori.global.audit.Auditable;
+import com.owori.global.audit.BaseTime;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member implements Auditable {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    private String name;
+
+    private String nickname;
+
+    private String profileImage;
+
+    private LocalDate birthDay;
+
+    @Enumerated(EnumType.STRING)
+    private Color color;
+
+    @Enumerated(EnumType.STRING)
+    private AuthProvider authProvider;
+
+    @Enumerated(EnumType.STRING)
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<Role> role = new ArrayList<>(List.of(Role.ROLE_USER));
+
+    @Setter
+    @Embedded
+    @Column(nullable = false)
+    private BaseTime baseTime;
+
+    @Builder
+    public Member(String name, String nickname, String profileImage, LocalDate birthDay, Color color, AuthProvider authProvider, List<Role> role, BaseTime baseTime) {
+        this.name = name;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.birthDay = birthDay;
+        this.color = color;
+        this.authProvider = authProvider;
+        this.role = role;
+        this.baseTime = baseTime;
+    }
+}

--- a/src/main/java/com/owori/domain/member/entity/Member.java
+++ b/src/main/java/com/owori/domain/member/entity/Member.java
@@ -36,6 +36,7 @@ public class Member implements Auditable {
     private AuthProvider authProvider;
 
     @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "member_role")
     @ElementCollection(fetch = FetchType.EAGER)
     private List<Role> role = new ArrayList<>(List.of(Role.ROLE_USER));
 
@@ -45,14 +46,12 @@ public class Member implements Auditable {
     private BaseTime baseTime;
 
     @Builder
-    public Member(String name, String nickname, String profileImage, LocalDate birthDay, Color color, AuthProvider authProvider, List<Role> role, BaseTime baseTime) {
+    public Member(String name, String nickname, String profileImage, LocalDate birthDay, Color color, AuthProvider authProvider) {
         this.name = name;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.birthDay = birthDay;
         this.color = color;
         this.authProvider = authProvider;
-        this.role = role;
-        this.baseTime = baseTime;
     }
 }

--- a/src/main/java/com/owori/domain/member/entity/Role.java
+++ b/src/main/java/com/owori/domain/member/entity/Role.java
@@ -1,0 +1,10 @@
+package com.owori.domain.member.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Role {
+    ROLE_ADMIN("관리자"), ROLE_USER("유저");
+
+    private final String toKorean;
+}

--- a/src/main/java/com/owori/domain/member/repository/JpaMemberRepository.java
+++ b/src/main/java/com/owori/domain/member/repository/JpaMemberRepository.java
@@ -1,0 +1,8 @@
+package com.owori.domain.member.repository;
+
+import com.owori.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaMemberRepository extends JpaRepository<Member, UUID>, MemberRepository {}

--- a/src/main/java/com/owori/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/owori/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.owori.domain.member.repository;
+
+import com.owori.domain.member.entity.Member;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MemberRepository {
+    Optional<Member> findById(UUID id);
+}

--- a/src/main/java/com/owori/domain/member/service/AuthService.java
+++ b/src/main/java/com/owori/domain/member/service/AuthService.java
@@ -1,0 +1,11 @@
+package com.owori.domain.member.service;
+
+import com.owori.config.security.jwt.JwtToken;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    public JwtToken refreshToken(String refreshToken, String accessToken) {
+        return null; // todo API Docs를 위한 메소드 생성
+    }
+}

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -1,0 +1,22 @@
+package com.owori.domain.member.service;
+
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.repository.MemberRepository;
+import com.owori.global.exception.EntityNotFoundException;
+import com.owori.global.service.EntityLoader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService implements EntityLoader<Member, UUID> {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member loadEntity(UUID id) {
+        return memberRepository.findById(id)
+                .orElseThrow(EntityNotFoundException::new);
+    }
+}

--- a/src/main/java/com/owori/global/audit/AuditListener.java
+++ b/src/main/java/com/owori/global/audit/AuditListener.java
@@ -1,0 +1,22 @@
+package com.owori.global.audit;
+
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@SoftDelete
+public class AuditListener {
+    @PrePersist
+    public void setCreatedAt(Auditable auditable) {
+        BaseTime baseTime = Optional.ofNullable(auditable.getBaseTime()).orElseGet(BaseTime::new);
+        baseTime.setCreatedAt(LocalDateTime.now().plusHours(9L));
+        auditable.setBaseTime(baseTime);
+    }
+
+    @PreUpdate
+    public void setUpdatedAt(Auditable auditable) {
+        BaseTime baseTime = auditable.getBaseTime();
+        baseTime.setUpdatedAt(LocalDateTime.now().plusHours(9L));
+    }
+}

--- a/src/main/java/com/owori/global/audit/Auditable.java
+++ b/src/main/java/com/owori/global/audit/Auditable.java
@@ -1,0 +1,12 @@
+package com.owori.global.audit;
+
+import java.time.LocalDateTime;
+
+@SoftDelete
+public interface Auditable {
+    BaseTime getBaseTime();
+    void setBaseTime(BaseTime baseTime);
+    default void delete() {
+        getBaseTime().setDeletedAt(LocalDateTime.now().plusHours(9L));
+    }
+}

--- a/src/main/java/com/owori/global/audit/BaseTime.java
+++ b/src/main/java/com/owori/global/audit/BaseTime.java
@@ -1,0 +1,19 @@
+package com.owori.global.audit;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Embeddable;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseTime {
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/owori/global/audit/SoftDelete.java
+++ b/src/main/java/com/owori/global/audit/SoftDelete.java
@@ -1,0 +1,18 @@
+package com.owori.global.audit;
+
+import org.hibernate.annotations.Where;
+
+import javax.persistence.EntityListeners;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Inherited
+@Target(TYPE)
+@Retention(RUNTIME)
+@EntityListeners(AuditListener.class)
+@Where(clause = "deleted_at is null")
+public @interface SoftDelete {}

--- a/src/main/java/com/owori/global/exception/EntityNotFoundException.java
+++ b/src/main/java/com/owori/global/exception/EntityNotFoundException.java
@@ -1,0 +1,9 @@
+package com.owori.global.exception;
+
+public class EntityNotFoundException extends IllegalArgumentException {
+    private static final String MESSAGE = "엔티티를 찾을 수 없습니다";
+
+    public EntityNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/owori/global/service/EntityLoader.java
+++ b/src/main/java/com/owori/global/service/EntityLoader.java
@@ -1,0 +1,5 @@
+package com.owori.global.service;
+
+public interface EntityLoader<T, ID> {
+    T loadEntity(ID id);
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,6 +22,9 @@ spring:
       hibernate:
         format_sql: true
 
+  main:
+    allow-bean-definition-overriding: true
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,6 +22,9 @@ spring:
       hibernate:
         format_sql: true
 
+  main:
+    allow-bean-definition-overriding: true
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,33 @@
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+    context-path: /api/v1
+
+spring:
+  config:
+    import:
+      - classpath:env.yml
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
+  main:
+    allow-bean-definition-overriding: true

--- a/src/test/java/com/owori/OworiApplicationTests.java
+++ b/src/test/java/com/owori/OworiApplicationTests.java
@@ -2,12 +2,12 @@ package com.owori;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class OworiApplicationTests {
-
 	@Test
 	void contextLoads() {
 	}
-
 }

--- a/src/test/java/com/owori/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/owori/domain/member/controller/AuthControllerTest.java
@@ -1,0 +1,51 @@
+package com.owori.domain.member.controller;
+
+import com.owori.config.security.jwt.JwtToken;
+import com.owori.domain.member.service.AuthService;
+import com.owori.support.docs.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.owori.support.docs.ApiDocsUtils.getDocumentRequest;
+import static com.owori.support.docs.ApiDocsUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Auth 컨트롤러의")
+class AuthControllerTest extends RestDocsTest {
+
+    @MockBean private AuthService authService;
+
+    @Test
+    @DisplayName("리프레시 검증 및 재발급 기능이 수행되는가")
+    void authorize() throws Exception {
+        //given
+        JwtToken expected = JwtToken.builder().accessToken("asdfiuer3oidwf12.asdfoihoihn23vs.grwoi6ghrweiog5h").refreshToken("ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb").build();
+        given(authService.refreshToken(any(), any())).willReturn(expected);
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/auth/refresh")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("refreshToken", "ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("accessToken", "asdfiuer3oidwf12.asdfoihoihn23vs.grwoi6ghrweiog5h"));
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").exists())
+                .andExpect(jsonPath("$.refresh_token").exists());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("refresh jwt token", getDocumentRequest(), getDocumentResponse()));
+    }
+}

--- a/src/test/java/com/owori/support/docs/ApiDocsUtils.java
+++ b/src/test/java/com/owori/support/docs/ApiDocsUtils.java
@@ -1,0 +1,16 @@
+package com.owori.support.docs;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+public interface ApiDocsUtils {
+    static OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(prettyPrint());
+    }
+
+    static OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(prettyPrint());
+    }
+}

--- a/src/test/java/com/owori/support/docs/RestDocsConfig.java
+++ b/src/test/java/com/owori/support/docs/RestDocsConfig.java
@@ -1,0 +1,19 @@
+package com.owori.support.docs;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@TestConfiguration
+public class RestDocsConfig {
+    @Bean
+    public RestDocsMockMvcConfigurationCustomizer restDocsMockMvcConfigurationCustomizer() {
+        return configurer ->
+                configurer
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint());
+    }
+}

--- a/src/test/java/com/owori/support/docs/RestDocsTest.java
+++ b/src/test/java/com/owori/support/docs/RestDocsTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -26,6 +28,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 public abstract class RestDocsTest {
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockBean
+    protected JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
     protected MockMvc mockMvc;
 
     protected String toRequestBody(Object value) throws JsonProcessingException {

--- a/src/test/java/com/owori/support/docs/RestDocsTest.java
+++ b/src/test/java/com/owori/support/docs/RestDocsTest.java
@@ -1,0 +1,43 @@
+package com.owori.support.docs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WebMvcTest
+@AutoConfigureRestDocs
+@Import(RestDocsConfig.class)
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+public abstract class RestDocsTest {
+    @Autowired
+    private ObjectMapper objectMapper;
+    protected MockMvc mockMvc;
+
+    protected String toRequestBody(Object value) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(value);
+    }
+
+    @BeforeEach
+    public void setupMockMvc(WebApplicationContext ctx, RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                        .apply(documentationConfiguration(restDocumentationContextProvider))
+                        .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                        .alwaysDo(print())
+                        .build();
+    }
+}


### PR DESCRIPTION
## 추가/수정한 기능 설명
- API 테스트 코드 및 Rest Docs 설정
- 예시 .adoc 작성
- BaseTime 세팅
- Member 엔티티 초안 작성

### 특이 사항
1. Member에서 role은 FetchType.LAZY가 아닌 EAGER로 설정해야 오류가 나지 않기 때문에 EAGER로 설정
2. BaseTime은 Embedded로 사용하기 위해 따로 콜백 리스너를 정의했습니다. 이 경우 Setter 사용 불가피합니다 
(BaseTime에 setter 붙여야합니다)

- **BaseTime과 SoftDelete, 그리고 API Docs 모두 사용방법은 노션 > Server에 작성해두었습니다.**
- 파일이 설정 때문에 좀 많습니다..ㅜㅠ 
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?