### PR TITLE
[FEAT] 가족 생성 API 및 코드 인증을 통한 가족 멤버 추가 API

### DIFF
--- a/src/main/java/com/owori/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/owori/domain/family/controller/FamilyController.java
@@ -18,13 +18,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class FamilyController {
     private final FamilyService familyService;
 
+    /**
+     * 가족 생성 컨트롤러입니다.
+     * 가족을 로그인한 유저를 포함하며 생성해 저장합니다. 초대코드를 response합니다.
+     * @param familyRequest 가족 그룹 명을 가지는 dto 입니다.
+     * @return 초대 코드를 가지는 response dto 입니다.
+     */
     @PostMapping
     public ResponseEntity<InviteCodeResponse> saveFamily(@RequestBody FamilyRequest familyRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(familyService.saveFamily(familyRequest));
     }
 
+    /**
+     * 가족 초대 코드 검증 및 멤버 추가 컨트롤러입니다.
+     * 초대 코드로 가족을 찾아 유효하면 멤버를 추가시킵니다.
+     * @param addMemberRequest 초대 코드를 가지고 있는 dto 입니다.
+     * @return 초대 코드를 가지는 response dto 입니다.
+     */
     @PostMapping("/members")
-    public ResponseEntity<Void> saveFamilyMember(@RequestBody AddMemberRequest addMemberRequest) {
+    public ResponseEntity<Void> addFamilyMember(@RequestBody AddMemberRequest addMemberRequest) {
         familyService.addMember(addMemberRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/owori/domain/family/dto/request/AddMemberRequest.java
+++ b/src/main/java/com/owori/domain/family/dto/request/AddMemberRequest.java
@@ -4,9 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Size;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class AddMemberRequest {
+    @Size(min = 10, max = 10)
     private String inviteCode;
 }

--- a/src/main/java/com/owori/domain/family/entity/Invite.java
+++ b/src/main/java/com/owori/domain/family/entity/Invite.java
@@ -9,27 +9,26 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
-import java.util.*;
+import java.util.UUID;
 
 @Getter
 @Entity
 @Where(clause = "deleted_at is null")
 @EntityListeners(AuditListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Family implements Auditable {
+public class Invite implements Auditable {
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
 
-    private String familyGroupName;
+    @Column(nullable = false, unique = true)
+    private String code;
 
-    @OneToMany(mappedBy = "family", cascade = CascadeType.PERSIST)
-    private Set<Member> members = new HashSet<>();
-
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "family")
-    private Invite invite;
+    @JoinColumn
+    @OneToOne(fetch = FetchType.LAZY)
+    private Family family;
 
     @Setter
     @Embedded
@@ -37,14 +36,8 @@ public class Family implements Auditable {
     private BaseTime baseTime;
 
     @Builder
-    public Family(String familyGroupName, Member member, String code) {
-        this.familyGroupName = familyGroupName;
-        this.invite = new Invite(code, this);
-        addMember(member);
-    }
-
-    public void addMember(Member member) {
-        this.members.add(member);
-        member.organizeFamily(this);
+    public Invite(String code, Family family) {
+        this.code = code;
+        this.family = family;
     }
 }

--- a/src/main/java/com/owori/domain/family/exception/InviteCodeDuplicateException.java
+++ b/src/main/java/com/owori/domain/family/exception/InviteCodeDuplicateException.java
@@ -1,0 +1,9 @@
+package com.owori.domain.family.exception;
+
+public class InviteCodeDuplicateException extends IllegalStateException {
+    private static final String MESSAGE = "초대 코드가 중복됩니다.";
+
+    public InviteCodeDuplicateException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/owori/domain/family/mapper/FamilyMapper.java
+++ b/src/main/java/com/owori/domain/family/mapper/FamilyMapper.java
@@ -1,0 +1,17 @@
+package com.owori.domain.family.mapper;
+
+import com.owori.domain.family.dto.request.FamilyRequest;
+import com.owori.domain.family.entity.Family;
+import com.owori.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FamilyMapper {
+    public Family toEntity(FamilyRequest familyRequest, Member member, String code) {
+        return Family.builder()
+                .familyGroupName(familyRequest.getFamilyGroupName())
+                .member(member)
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/owori/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/owori/domain/family/repository/FamilyRepository.java
@@ -7,4 +7,7 @@ import java.util.UUID;
 
 public interface FamilyRepository {
     Optional<Family> findById(UUID id);
+    Optional<Family> findByInviteCode(String code);
+    Family save(Family family);
+    boolean existsByInviteCode(String code);
 }

--- a/src/main/java/com/owori/domain/family/service/FamilyService.java
+++ b/src/main/java/com/owori/domain/family/service/FamilyService.java
@@ -33,7 +33,7 @@ public class FamilyService implements EntityLoader<Family, UUID> {
         return new InviteCodeResponse(code);
     }
 
-    private void validateCode(String code) {
+    private void validateCode(final String code) {
         if (familyRepository.existsByInviteCode(code)) {
             throw new InviteCodeDuplicateException();
         }
@@ -49,7 +49,7 @@ public class FamilyService implements EntityLoader<Family, UUID> {
         familyRepository.findByInviteCode(addMemberRequest.getInviteCode().strip())
                 .ifPresent(family -> {
                     Invite invite = family.getInvite();
-                    if (isValidCode(invite)) {
+                    if (isInValidCode(invite)) {
                         invite.delete();
                         return;
                     }
@@ -57,7 +57,7 @@ public class FamilyService implements EntityLoader<Family, UUID> {
                 });
     }
 
-    private boolean isValidCode(Invite invite) {
+    private boolean isInValidCode(final Invite invite) {
         return invite.getBaseTime().getCreatedAt().plusMinutes(30L).isBefore(LocalDateTime.now());
     }
 

--- a/src/main/java/com/owori/domain/family/service/FamilyService.java
+++ b/src/main/java/com/owori/domain/family/service/FamilyService.java
@@ -4,29 +4,65 @@ import com.owori.domain.family.dto.request.AddMemberRequest;
 import com.owori.domain.family.dto.request.FamilyRequest;
 import com.owori.domain.family.dto.response.InviteCodeResponse;
 import com.owori.domain.family.entity.Family;
+import com.owori.domain.family.entity.Invite;
+import com.owori.domain.family.exception.InviteCodeDuplicateException;
+import com.owori.domain.family.mapper.FamilyMapper;
 import com.owori.domain.family.repository.FamilyRepository;
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.service.AuthService;
 import com.owori.global.exception.EntityNotFoundException;
 import com.owori.global.service.EntityLoader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class FamilyService implements EntityLoader<Family, UUID> {
     private final FamilyRepository familyRepository;
+    private final FamilyMapper familyMapper;
+    private final AuthService authService;
 
-    public InviteCodeResponse saveFamily(FamilyRequest familyRequest) {
-        return null; // todo 로직 작성
+    public InviteCodeResponse saveFamily(final FamilyRequest familyRequest) {
+        Member member = authService.getLoginUser();
+        String code = generateRandomInviteCode();
+        familyRepository.save(familyMapper.toEntity(familyRequest, member, code));
+
+        return new InviteCodeResponse(code);
     }
 
-    public void addMember(AddMemberRequest addMemberRequest) {
-        // todo 로직 작성
+    private void validateCode(String code) {
+        if (familyRepository.existsByInviteCode(code)) {
+            throw new InviteCodeDuplicateException();
+        }
+    }
+
+    private String generateRandomInviteCode() {
+        String code = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+        validateCode(code);
+        return code;
+    }
+
+    public void addMember(final AddMemberRequest addMemberRequest) {
+        familyRepository.findByInviteCode(addMemberRequest.getInviteCode().strip())
+                .ifPresent(family -> {
+                    Invite invite = family.getInvite();
+                    if (isValidCode(invite)) {
+                        invite.delete();
+                        return;
+                    }
+                    family.addMember(authService.getLoginUser());
+                });
+    }
+
+    private boolean isValidCode(Invite invite) {
+        return invite.getBaseTime().getCreatedAt().plusMinutes(30L).isBefore(LocalDateTime.now());
     }
 
     @Override
-    public Family loadEntity(UUID id) {
+    public Family loadEntity(final UUID id) {
         return familyRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
     }

--- a/src/main/java/com/owori/domain/member/entity/Member.java
+++ b/src/main/java/com/owori/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.owori.domain.member.entity;
 
+import com.owori.domain.family.entity.Family;
 import com.owori.global.audit.AuditListener;
 import com.owori.global.audit.Auditable;
 import com.owori.global.audit.BaseTime;
@@ -39,6 +40,10 @@ public class Member implements Auditable {
     @Enumerated(EnumType.STRING)
     private Color color;
 
+    @JoinColumn
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Family family;
+
     @Enumerated(EnumType.STRING)
     @CollectionTable(name = "member_role")
     @ElementCollection(fetch = FetchType.EAGER)
@@ -60,5 +65,9 @@ public class Member implements Auditable {
 
     public List<SimpleGrantedAuthority> getRole() {
         return role.stream().map(Role::name).map(SimpleGrantedAuthority::new).toList();
+    }
+
+    public void organizeFamily(Family family) {
+        this.family = family;
     }
 }

--- a/src/test/java/com/owori/domain/family/controller/FamilyControllerTest.java
+++ b/src/test/java/com/owori/domain/family/controller/FamilyControllerTest.java
@@ -4,7 +4,6 @@ import com.owori.domain.family.dto.request.AddMemberRequest;
 import com.owori.domain.family.dto.request.FamilyRequest;
 import com.owori.domain.family.dto.response.InviteCodeResponse;
 import com.owori.domain.family.service.FamilyService;
-import com.owori.domain.member.controller.AuthController;
 import com.owori.support.docs.RestDocsTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import static com.owori.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.owori.support.docs.ApiDocsUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -31,6 +29,7 @@ class FamilyControllerTest extends RestDocsTest {
     @MockBean private FamilyService familyService;
 
     @Test
+    @DisplayName("가족 생성이 수행되는가")
     void saveFamily() throws Exception {
         //given
         InviteCodeResponse expected = new InviteCodeResponse("oworiinvite");
@@ -55,6 +54,7 @@ class FamilyControllerTest extends RestDocsTest {
     }
 
     @Test
+    @DisplayName("가족 인증을 통한 멤버 추가가 수행되는가")
     void saveFamilyMember() throws Exception {
         //given
         doNothing().when(familyService).addMember(any());

--- a/src/test/java/com/owori/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/com/owori/domain/family/service/FamilyServiceTest.java
@@ -1,0 +1,76 @@
+package com.owori.domain.family.service;
+
+import com.owori.domain.family.dto.request.AddMemberRequest;
+import com.owori.domain.family.dto.request.FamilyRequest;
+import com.owori.domain.family.dto.response.InviteCodeResponse;
+import com.owori.domain.family.entity.Family;
+import com.owori.domain.family.repository.FamilyRepository;
+import com.owori.domain.member.entity.AuthProvider;
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.entity.OAuth2Info;
+import com.owori.support.database.DatabaseTest;
+import com.owori.support.database.LoginTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@DatabaseTest
+@DisplayName("Family 서비스의")
+class FamilyServiceTest extends LoginTest {
+    @Autowired private FamilyService familyService;
+    @Autowired private FamilyRepository familyRepository;
+
+    @Test
+    @DisplayName("가족 생성이 수행되는가")
+    void saveFamily() {
+        //given
+        String familyName = "오월이 가족";
+
+        //when
+        InviteCodeResponse result = familyService.saveFamily(new FamilyRequest(familyName));
+
+        //then
+        Family family = familyRepository.findByInviteCode(result.getInviteCode()).orElseThrow();
+
+        assertThat(family.getFamilyGroupName()).isEqualTo(familyName);
+        assertThat(family.getMembers()).hasSize(1).hasSameElementsAs(Set.of(loginUser));
+    }
+
+    @Test
+    @DisplayName("인증을 통한 멤버 추가가 수행되는가")
+    void addMember() {
+        //given
+        String familyName = "오월이 가족";
+        String code = familyService.saveFamily(new FamilyRequest(familyName)).getInviteCode();
+
+        Member member = Member.builder().name("test").oAuth2Info(new OAuth2Info("123123", AuthProvider.APPLE)).build();
+        when(authService.getLoginUser()).thenReturn(member);
+
+        //when
+        familyService.addMember(new AddMemberRequest(code));
+
+        //then
+        Family family = familyRepository.findByInviteCode(code).orElseThrow();
+        assertThat(family.getMembers()).hasSize(2).hasSameElementsAs(Set.of(member, loginUser));
+    }
+
+    @Test
+    @DisplayName("id를 통한 조회가 수행되는가")
+    void loadEntity() {
+        //given
+        Family family = familyRepository.save(Family.builder().member(loginUser).build());
+
+        //when
+        Family result = familyService.loadEntity(family.getId());
+
+        //then
+        assertThat(family).isEqualTo(result);
+    }
+}

--- a/src/test/java/com/owori/support/database/DatabaseTest.java
+++ b/src/test/java/com/owori/support/database/DatabaseTest.java
@@ -1,0 +1,17 @@
+package com.owori.support.database;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Transactional
+@ActiveProfiles("test")
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+public @interface DatabaseTest {}

--- a/src/test/java/com/owori/support/database/LoginTest.java
+++ b/src/test/java/com/owori/support/database/LoginTest.java
@@ -1,0 +1,31 @@
+package com.owori.support.database;
+
+import com.owori.domain.member.entity.AuthProvider;
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.entity.OAuth2Info;
+import com.owori.domain.member.repository.MemberRepository;
+import com.owori.domain.member.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.mockito.Mockito.when;
+
+@DatabaseTest
+public abstract class LoginTest {
+
+    @MockBean
+    protected AuthService authService;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+    protected Member loginUser;
+
+    @BeforeEach
+    public void setup() {
+        Member member = new Member("오월이", new OAuth2Info("123", AuthProvider.KAKAO));
+        loginUser = memberRepository.save(member);
+        when(authService.getLoginUserId()).thenReturn(loginUser.getId());
+        when(authService.getLoginUser()).thenReturn(loginUser);
+    }
+}


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 가족 생성 API
- 코드 인증을 통한 가족 멤버 추가 API
- 위 두 API에 대한 테스트 코드

### 특이 사항
- 서비스단 테스트 코드는 JWT로 인해 테스트 하기 어려운 부분 때문에 작성했습니다...
- 초대 코드를 디자인 참고해서 글자 10자로 고정했는데 혹시 수정해야하면 말해주세용

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?