### PR TITLE
[CHORE] member profile 업데이트, 회원 탈퇴 및 family name 업데이트, Jackson Config

### DIFF
--- a/src/docs/family.adoc
+++ b/src/docs/family.adoc
@@ -10,3 +10,6 @@ operation::save family[snippets='http-request,http-response']
 
 === 가족 멤버 초대코드로 추가
 operation::add member to family[snippets='http-request,http-response']
+
+=== 가족 그룹 이름 수정
+operation::update family group name[snippets='http-request,http-response']

--- a/src/docs/member.adoc
+++ b/src/docs/member.adoc
@@ -13,3 +13,9 @@ operation::update member details[snippets='http-request,http-response']
 
 === 멤버 프로필 이미지 저장
 operation::update member profile image[snippets='http-request,http-response']
+
+=== 멤버 프로필 업데이트
+operation::update member profile[snippets='http-request,http-response']
+
+=== 멤버 회원 탈퇴
+operation::delete member[snippets='http-request,http-response']

--- a/src/main/java/com/owori/config/mapper/LocalDateDeserializer.java
+++ b/src/main/java/com/owori/config/mapper/LocalDateDeserializer.java
@@ -1,0 +1,17 @@
+package com.owori.config.mapper;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
+    @Override
+    public LocalDate deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        return LocalDate.parse(p.getValueAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+}

--- a/src/main/java/com/owori/config/mapper/LocalDateSerializer.java
+++ b/src/main/java/com/owori/config/mapper/LocalDateSerializer.java
@@ -1,0 +1,16 @@
+package com.owori.config.mapper;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateSerializer extends JsonSerializer<LocalDate> {
+    @Override
+    public void serialize(LocalDate value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(DateTimeFormatter.ofPattern("yyyy-MM-dd").format(value));
+    }
+}

--- a/src/main/java/com/owori/config/mapper/LocalDateTimeDeserializer.java
+++ b/src/main/java/com/owori/config/mapper/LocalDateTimeDeserializer.java
@@ -1,0 +1,17 @@
+package com.owori.config.mapper;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+    @Override
+    public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        return LocalDateTime.parse(p.getValueAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+}

--- a/src/main/java/com/owori/config/mapper/LocalDateTimeSerializer.java
+++ b/src/main/java/com/owori/config/mapper/LocalDateTimeSerializer.java
@@ -1,0 +1,16 @@
+package com.owori.config.mapper;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+    @Override
+    public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(value));
+    }
+}

--- a/src/main/java/com/owori/config/mapper/ObjectMapperConfig.java
+++ b/src/main/java/com/owori/config/mapper/ObjectMapperConfig.java
@@ -1,0 +1,33 @@
+package com.owori.config.mapper;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Configuration
+public class ObjectMapperConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .registerModule(dateTimeModule());
+    }
+
+    @Bean
+    public Module dateTimeModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(LocalDate.class, new LocalDateSerializer());
+        module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+        module.addDeserializer(LocalDate.class, new LocalDateDeserializer());
+        module.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+        return module;
+    }
+}

--- a/src/main/java/com/owori/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/owori/domain/family/controller/FamilyController.java
@@ -35,11 +35,23 @@ public class FamilyController {
      * 가족 초대 코드 검증 및 멤버 추가 컨트롤러입니다.
      * 초대 코드로 가족을 찾아 유효하면 멤버를 추가시킵니다.
      * @param addMemberRequest 초대 코드를 가지고 있는 dto 입니다.
-     * @return 초대 코드를 가지는 response dto 입니다.
+     * @return 바디로 response 하는 정보는 없습니다.
      */
     @PostMapping("/members")
     public ResponseEntity<Void> addFamilyMember(@RequestBody @Valid AddMemberRequest addMemberRequest) {
         familyService.addMember(addMemberRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 가족 그룹 이름을 수정하는 컨트롤러입니다.
+     * 가족 그룹 이름을 받아와 업데이트합니다.
+     * @param familyRequest 업데이트할 가족 그룹 이름을 가집니다.
+     * @return 바디로 response 하는 정보는 없습니다.
+     */
+    @PostMapping("/group-name")
+    public ResponseEntity<Void> updateGroupName(@RequestBody @Valid FamilyRequest familyRequest) {
+        familyService.updateGroupName(familyRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/owori/domain/family/entity/Family.java
+++ b/src/main/java/com/owori/domain/family/entity/Family.java
@@ -49,4 +49,8 @@ public class Family implements Auditable {
         this.members.add(member);
         member.organizeFamily(this);
     }
+
+    public void updateGroupName(String familyGroupName) {
+        this.familyGroupName = familyGroupName;
+    }
 }

--- a/src/main/java/com/owori/domain/family/service/FamilyService.java
+++ b/src/main/java/com/owori/domain/family/service/FamilyService.java
@@ -14,6 +14,7 @@ import com.owori.global.exception.EntityNotFoundException;
 import com.owori.global.service.EntityLoader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -65,5 +66,11 @@ public class FamilyService implements EntityLoader<Family, UUID> {
     public Family loadEntity(final UUID id) {
         return familyRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
+    }
+
+    @Transactional
+    public void updateGroupName(final FamilyRequest groupNameRequest) {
+        Family family = authService.getLoginUser().getFamily();
+        family.updateGroupName(groupNameRequest.getFamilyGroupName());
     }
 }

--- a/src/main/java/com/owori/domain/member/controller/MemberController.java
+++ b/src/main/java/com/owori/domain/member/controller/MemberController.java
@@ -1,16 +1,14 @@
 package com.owori.domain.member.controller;
 
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
+import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.response.MemberJwtResponse;
 import com.owori.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
@@ -55,6 +53,29 @@ public class MemberController {
     @PostMapping("/profile-image")
     public ResponseEntity<Void> updateMemberProfileImage(MultipartFile profileImage) throws IOException {
         memberService.updateMemberProfileImage(profileImage);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 멤버 프로필 업데이트 컨트롤러입니다.
+     * 멤버 프로필 정보를 받아와 업데이트한 후 상태코드 200번을 빈 body 와 함께 response 합니다.
+     * @param memberProfileRequest 멤버의 수정 요청한 프로필 정보입니다.
+     * @return 바디로 response 하는 정보는 없습니다.
+     */
+    @PostMapping("/profile")
+    public ResponseEntity<Void> updateMemberProfile(@RequestBody @Valid MemberProfileRequest memberProfileRequest) {
+        memberService.updateMemberProfile(memberProfileRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 멤버 회원 탈퇴 컨트롤러입니다.
+     * 멤버를 삭제한 후 상태코드 200번을 빈 body 와 함께 response 합니다.
+     * @return 바디로 response 하는 정보는 없습니다.
+     */
+    @DeleteMapping
+    public ResponseEntity<Void> deleteMember() {
+        memberService.deleteMember();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/owori/domain/member/dto/request/MemberProfileRequest.java
+++ b/src/main/java/com/owori/domain/member/dto/request/MemberProfileRequest.java
@@ -1,0 +1,23 @@
+package com.owori.domain.member.dto.request;
+
+import com.owori.domain.member.entity.Color;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PastOrPresent;
+import javax.validation.constraints.Size;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberProfileRequest {
+    @Size(min = 1, max = 7)
+    private String nickname;
+    @PastOrPresent
+    private LocalDate birthday;
+    @NotNull
+    private Color color;
+}

--- a/src/main/java/com/owori/domain/member/entity/Member.java
+++ b/src/main/java/com/owori/domain/member/entity/Member.java
@@ -13,6 +13,7 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -71,8 +72,20 @@ public class Member implements Auditable {
         updateColor(Color.getNextColor(familyColors));
     }
 
-    public void updateColor(Color color) {
+    private void updateColor(Color color) {
+        Set<Member> familyMembers = this.family.getMembers();
+        if (hasNoDuplicateColor(familyMembers) && hasSameColor(color, familyMembers)) {
+            return;
+        }
         this.color = color;
+    }
+
+    private boolean hasNoDuplicateColor(Set<Member> familyMembers) {
+        return familyMembers.size() <= Color.values().length;
+    }
+
+    private boolean hasSameColor(Color color, Set<Member> familyMembers) {
+        return familyMembers.stream().map(Member::getColor).anyMatch(color::equals);
     }
 
     public List<SimpleGrantedAuthority> getRole() {
@@ -86,5 +99,11 @@ public class Member implements Auditable {
 
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    public void updateProfile(String nickname, LocalDate birthday, Color color) {
+        this.nickname = nickname;
+        this.birthDay = birthday;
+        updateColor(color);
     }
 }

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.owori.domain.member.service;
 
 import com.owori.config.security.jwt.JwtToken;
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
+import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.response.MemberJwtResponse;
 import com.owori.domain.member.entity.Member;
@@ -63,5 +64,19 @@ public class MemberService implements EntityLoader<Member, UUID> {
             throw new NoSuchProfileImageException();
         }
         return s3ImageComponent.uploadImage("profile-image", profileImage);
+    }
+
+    @Transactional
+    public void updateMemberProfile(final MemberProfileRequest memberProfileRequest) {
+        Member member = authService.getLoginUser();
+        member.updateProfile(
+                memberProfileRequest.getNickname(),
+                memberProfileRequest.getBirthday(),
+                memberProfileRequest.getColor());
+    }
+
+    @Transactional
+    public void deleteMember() {
+        authService.getLoginUser().delete();
     }
 }

--- a/src/test/java/com/owori/domain/family/controller/FamilyControllerTest.java
+++ b/src/test/java/com/owori/domain/family/controller/FamilyControllerTest.java
@@ -70,7 +70,7 @@ class FamilyControllerTest extends RestDocsTest {
                                 .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
                                 .header("memberId", UUID.randomUUID().toString())
                                 .content(
-                                        toRequestBody(new AddMemberRequest("우리가족"))));
+                                        toRequestBody(new AddMemberRequest("길이가10인문자열!"))));
 
         //then
         perform.andExpect(status().isOk());
@@ -78,5 +78,29 @@ class FamilyControllerTest extends RestDocsTest {
         //docs
         perform.andDo(print())
                 .andDo(document("add member to family", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("가족 그룹 이름 업데이트가 수행되는가")
+    void updateGroupName() throws Exception {
+        //given
+        doNothing().when(familyService).updateGroupName(any());
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/families/group-name")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString())
+                                .content(
+                                        toRequestBody(new FamilyRequest("우리가족"))));
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("update family group name", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/src/test/java/com/owori/domain/family/service/FamilyServiceTest.java
+++ b/src/test/java/com/owori/domain/family/service/FamilyServiceTest.java
@@ -10,7 +10,6 @@ import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.entity.OAuth2Info;
 import com.owori.support.database.DatabaseTest;
 import com.owori.support.database.LoginTest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @DatabaseTest
@@ -72,5 +70,20 @@ class FamilyServiceTest extends LoginTest {
 
         //then
         assertThat(family).isEqualTo(result);
+    }
+
+    @Test
+    @DisplayName("가족 그룹명 업데이트가 수행되는가")
+    void updateGroupName() {
+        //given
+        Family family = familyRepository.save(Family.builder().familyGroupName("오월이가족").member(loginUser).build());
+
+        //when
+        String resultName = "우리가족";
+        familyService.updateGroupName(new FamilyRequest(resultName));
+
+        //then
+        Family result = familyService.loadEntity(family.getId());
+        assertThat(result.getFamilyGroupName()).isEqualTo(resultName);
     }
 }

--- a/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
@@ -1,10 +1,12 @@
 package com.owori.domain.member.controller;
 
 import com.owori.config.security.jwt.JwtToken;
-import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
+import com.owori.domain.member.dto.request.MemberProfileRequest;
+import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.response.MemberJwtResponse;
 import com.owori.domain.member.entity.AuthProvider;
+import com.owori.domain.member.entity.Color;
 import com.owori.domain.member.service.MemberService;
 import com.owori.support.docs.RestDocsTest;
 import org.junit.jupiter.api.DisplayName;
@@ -18,13 +20,11 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
 
 import static com.owori.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.owori.support.docs.ApiDocsUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -111,5 +111,50 @@ class MemberControllerTest extends RestDocsTest {
         //docs
         perform.andDo(print())
                 .andDo(document("update member profile image", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("멤버 프로필 업데이트 수행되는가")
+    void updateMemberProfile() throws Exception {
+        //given
+        doNothing().when(memberService).updateMemberProfile(any());
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/members/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toRequestBody(new MemberProfileRequest("오월이", LocalDate.now(), Color.GREEN)))
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString()));
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("update member profile", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("멤버 회원탈퇴가 수행되는가")
+    void deleteMember() throws Exception {
+        //given
+        doNothing().when(memberService).deleteMember();
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/members")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString()));
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("delete member", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
@@ -1,28 +1,30 @@
 package com.owori.domain.member.service;
 
-import com.owori.config.security.jwt.JwtToken;
+import com.owori.domain.family.entity.Family;
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
-import com.owori.domain.member.dto.request.MemberRequest;
-import com.owori.domain.member.dto.response.MemberJwtResponse;
-import com.owori.domain.member.entity.AuthProvider;
+import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.entity.Color;
 import com.owori.domain.member.entity.Member;
+import com.owori.global.exception.EntityNotFoundException;
 import com.owori.support.database.DatabaseTest;
 import com.owori.support.database.LoginTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mock.web.MockMultipartFile;
 
+import javax.persistence.EntityManager;
 import java.time.LocalDate;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @DatabaseTest
 @DisplayName("Member 서비스의")
 class MemberServiceTest extends LoginTest {
     @Autowired private MemberService memberService;
+    @Autowired private EntityManager em;
 
     @Test
     @DisplayName("id로 조회가 수행되는가")
@@ -80,5 +82,39 @@ class MemberServiceTest extends LoginTest {
 
         //then
 
+    }
+
+    @Test
+    @DisplayName("프로필 업데이트가 수행되는가")
+    void updateProfile() {
+        //given
+        Family family = new Family("우리가족", loginUser, "1231231234");
+
+        //when
+        String nickname = "오월이";
+        LocalDate birthday = LocalDate.now();
+        Color color = Color.GREEN;
+        memberService.updateMemberProfile(new MemberProfileRequest(nickname, birthday, color));
+
+        //then
+        Member member = memberService.loadEntity(loginUser.getId());
+        assertThat(member.getBirthDay()).isEqualTo(birthday);
+        assertThat(member.getNickname()).isEqualTo(nickname);
+        assertThat(member.getColor()).isEqualTo(color);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴가 수행되는가")
+    void deleteMember() {
+        //given
+        UUID id = loginUser.getId();
+
+        //when
+        memberService.deleteMember();
+        em.flush();
+        em.clear();
+
+        //then
+        assertThrows(EntityNotFoundException.class, () -> memberService.loadEntity(id));
     }
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. 프로필 수정 API (Docs 포함)
2. 회원 탈퇴 API (Docs 포함)
3. 가족 그룹명 수정 API (Docs 포함)
4. LocalDate, LocalDateTime Jackson Custom Serializer/Deserializer 구현

## 특이 사항
- docs만 하려고 하다가 api 로직도 구현했습니다.....

- 앞으로 LocalDateTime 이랑 LocalDate DTO에서 써야할 때 String 대신 그냥 써주시고 어노테이션도 안붙이셔도 됩니다.
- 아래 스샷은 Dto 클래스를 request하고 바로 response 했을 때의 결과입니다.

<img width="685" alt="스크린샷 2023-07-11 오후 4 02 44" src="https://github.com/TeamOwori/Owori-Server/assets/89020004/ba661655-eb56-4d2e-a944-be58d208d4bf">

![image](https://github.com/TeamOwori/Owori-Server/assets/89020004/f71bd0cd-6e5f-45d1-a73c-848cea51fc30)

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?