### PR TITLE
[FEAT] 이야기 목록형 조회 (최신순/날짜순) API 추가

### DIFF
--- a/src/main/java/com/owori/domain/heart/dto/HeartStatusResponse.java
+++ b/src/main/java/com/owori/domain/heart/dto/HeartStatusResponse.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class HeartStatusResponse {
-    private boolean isLiked;
+    private Boolean isLiked;
 }

--- a/src/main/java/com/owori/domain/story/controller/StoryController.java
+++ b/src/main/java/com/owori/domain/story/controller/StoryController.java
@@ -42,17 +42,23 @@ public class StoryController {
      * @return 앨범형 조회 dto가 반환됩니다.
      */
     @GetMapping("/album")
-    public ResponseEntity<FindAlbumStoryGroupResponse> findAlbumStory(@PageableDefault(sort = "createAt", direction = DESC) Pageable pageable,
+    public ResponseEntity<FindAlbumStoryGroupResponse> findAlbumStory(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
                                                                       @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed){
 
         return ResponseEntity.ok(storyService.findAlbumStory(pageable, lastViewed));
     }
 
+    /**
+     * 이야기를 목록형으로 조회합니다.
+     * @param pageable
+     * @param lastViewed 조회할 게시글의 기준 (year_month) 입니다.
+     * @return 앨범형 조회 dto가 반환됩니다.
+     */
     @GetMapping("/list")
     public ResponseEntity<FindListStoryGroupResponse> findListStory(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
-                                                                    @RequestParam Long lastId){
+                                                                    @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed){
 
-        return ResponseEntity.ok(storyService.findListStory(pageable, lastId));
+        return ResponseEntity.ok(storyService.findListStory(pageable, lastViewed));
     }
 
     @GetMapping("/{storyId}")

--- a/src/main/java/com/owori/domain/story/dto/request/AddStoryRequest.java
+++ b/src/main/java/com/owori/domain/story/dto/request/AddStoryRequest.java
@@ -19,5 +19,5 @@ public class AddStoryRequest {
     private String title;
 
     private String contents;
-    private List<UUID> imageId;
+    private List<UUID> imagesId;
 }

--- a/src/main/java/com/owori/domain/story/dto/response/FindListStoryResponse.java
+++ b/src/main/java/com/owori/domain/story/dto/response/FindListStoryResponse.java
@@ -3,6 +3,8 @@ package com.owori.domain.story.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 @AllArgsConstructor
 public class FindListStoryResponse {
@@ -10,8 +12,9 @@ public class FindListStoryResponse {
     private String title;
     private String contents;
     private String image;
-    private Long heartCnt;
-    private Long commentCnt;
+    private Integer heartCnt;
+    private Integer commentCnt;
     private String writer;
-    private String date;
+    private LocalDate startDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/com/owori/domain/story/repository/StoryOrderConverter.java
+++ b/src/main/java/com/owori/domain/story/repository/StoryOrderConverter.java
@@ -21,7 +21,7 @@ public class StoryOrderConverter implements OrderConverter {
     }
 
     private void initializeMap() {
-        keywordMap.put("createAt", story.baseTime.createdAt);
+        keywordMap.put("createdAt", story.baseTime.createdAt);
         keywordMap.put("startDate", story.startDate);
     }
 

--- a/src/main/java/com/owori/domain/story/repository/StoryRepositoryCustom.java
+++ b/src/main/java/com/owori/domain/story/repository/StoryRepositoryCustom.java
@@ -8,7 +8,8 @@ import org.springframework.data.domain.Slice;
 import java.time.LocalDate;
 
 public interface StoryRepositoryCustom {
-    Slice<Story> findAllStoryByCreateAt(Pageable pageable, LocalDate lastId, Member member);
-    Slice<Story> findAllStoryByEventAt(Pageable pageable, LocalDate startDate, Member member);
-
+    Slice<Story> findAllAlbumStoryByCreatedAt(Pageable pageable, LocalDate lastId, Member member);
+    Slice<Story> findAllAlbumStoryByEventAt(Pageable pageable, LocalDate startDate, Member member);
+    Slice<Story> findAllListStoryByCreatedAt(Pageable pageable, Member member, LocalDate startDate);
+    Slice<Story> findAllListStoryByEventAt(Pageable pageable, Member member, LocalDate startDate);
 }

--- a/src/main/java/com/owori/domain/story/service/StoryService.java
+++ b/src/main/java/com/owori/domain/story/service/StoryService.java
@@ -36,9 +36,9 @@ public class StoryService implements EntityLoader<Story, Long> {
     public IdResponse<Long> addStory(AddStoryRequest request) {
         Member loginUser = authService.getLoginUser();
         Story newStory = storyRepository.save(storyMapper.toEntity(request, loginUser));
-        List<UUID> imageIds = request.getImageId();
-        if(imageIds != null){
-            imageService.updateStory(newStory, imageIds);
+        List<UUID> imagesIds = request.getImagesId();
+        if(imagesIds != null){
+            imageService.updateStory(newStory, imagesIds);
         }
         return new IdResponse<>(newStory.getId());
     }

--- a/src/test/java/com/owori/domain/heart/service/HeartServiceTest.java
+++ b/src/test/java/com/owori/domain/heart/service/HeartServiceTest.java
@@ -43,7 +43,7 @@ public class HeartServiceTest extends LoginTest {
         Set<Heart> hearts = storyRepository.findById(story.getId()).get().getHearts();
         Heart heart = heartRepository.findByMemberAndStory(member, story).get();
 
-        assertThat(response.isLiked()).isEqualTo(true);
+        assertThat(response.getIsLiked()).isEqualTo(true);
         assertThat(heart.getStory()).isEqualTo(story);
         assertThat(heart.getMember()).isEqualTo(member);
         assertThat(hearts.iterator().next()).isEqualTo(heart);
@@ -65,7 +65,7 @@ public class HeartServiceTest extends LoginTest {
         Set<Heart> hearts = storyRepository.findById(story.getId()).get().getHearts();
         Heart heart = heartRepository.findByMemberAndStory(member, story).orElse(null);
 
-        assertThat(response.isLiked()).isEqualTo(false);
+        assertThat(response.getIsLiked()).isEqualTo(false);
         assertThat(heart).isEqualTo(null);
         assertThat(hearts.isEmpty()).isEqualTo(true);
     }

--- a/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
+++ b/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
@@ -64,11 +64,9 @@ public class StoryControllerTest extends RestDocsTest{
     @DisplayName("GET /stories/list 이야기 리스트형 조회 API 테스트")
     void findStoryList() throws Exception {
         //given
-        Long lastId = 2L;
-
         List<FindListStoryResponse> response = List.of(
-                new FindListStoryResponse(1L,"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "image.png", 5L, 2L, "허망고", "2022-02-01"),
-                new FindListStoryResponse(2L,"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "image.png", 2L, 5L, "허지롱이", "2022-02-01 - 2022-02-04"));
+                new FindListStoryResponse(1L,"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "image.png", 5, 2, "허망고", LocalDate.of(2022, 02, 01), null),
+                new FindListStoryResponse(2L,"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "image.png", 2, 5, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)));
 
         FindListStoryGroupResponse findListStoryGroupResponse = new FindListStoryGroupResponse(response, true);
         given(storyService.findListStory(any(),any())).willReturn(findListStoryGroupResponse);
@@ -77,8 +75,8 @@ public class StoryControllerTest extends RestDocsTest{
         ResultActions perform =
                 mockMvc.perform(
                         get("/stories/list")
-                                .param("sort", "createAt")
-                                .param("lastId", lastId.toString())
+                                .param("sort", "createdAt")
+                                .param("lastViewed","2023-07-31")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
                                 .header("memberId", UUID.randomUUID().toString())
@@ -124,7 +122,7 @@ public class StoryControllerTest extends RestDocsTest{
         ResultActions perform =
                 mockMvc.perform(
                         get("/stories/album")
-                                .param("sort", "createAt")
+                                .param("sort", "createdAt")
                                 .param("lastViewed","2023-07-31")
                                 .param("size", size)
                                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 이슈번호 
Closes #22 

## 추가/수정한 기능 설명
- 이야기 목록형 조회(최신순/날짜순) api를 추가했습니다. 
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?