### PR TITLE
[FEAT] 서로에게 한마디 API 

### DIFF
--- a/src/main/java/com/owori/domain/member/entity/Member.java
+++ b/src/main/java/com/owori/domain/member/entity/Member.java
@@ -11,10 +11,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import javax.persistence.*;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Getter
 @Entity
@@ -105,5 +102,18 @@ public class Member implements Auditable {
         this.nickname = nickname;
         this.birthDay = birthday;
         updateColor(color);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(oAuth2Info, member.oAuth2Info);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(oAuth2Info);
     }
 }

--- a/src/main/java/com/owori/domain/member/entity/OAuth2Info.java
+++ b/src/main/java/com/owori/domain/member/entity/OAuth2Info.java
@@ -9,6 +9,7 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import java.util.Objects;
 
 @Getter
 @Embeddable
@@ -20,4 +21,17 @@ public class OAuth2Info {
 
     @Enumerated(EnumType.STRING)
     private AuthProvider authProvider;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OAuth2Info that = (OAuth2Info) o;
+        return Objects.equals(token, that.token) && authProvider == that.authProvider;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token, authProvider);
+    }
 }

--- a/src/main/java/com/owori/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/owori/domain/member/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.owori.domain.member.repository;
 import com.owori.domain.member.entity.AuthProvider;
 import com.owori.domain.member.entity.Member;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +13,6 @@ public interface MemberRepository {
     Member save(Member member);
     void updateRefreshToken(UUID id, String refreshToken);
     String findRefreshTokenById(UUID id);
+    List<Member> findAllByIdIn(List<UUID> memberIds);
+
 }

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -78,5 +79,14 @@ public class MemberService implements EntityLoader<Member, UUID> {
     @Transactional
     public void deleteMember() {
         authService.getLoginUser().delete();
+    }
+
+    /**
+     * 멤버 아이디 리스트를 통해 멤버 리스트를 반환해주는 함수
+     * @param memberIds 멤버 아이디 리스트
+     * @return 멤버 리스트
+     */
+    public List<Member> findMembersByIds(List<UUID> memberIds) {
+        return memberRepository.findAllByIdIn(memberIds);
     }
 }

--- a/src/main/java/com/owori/domain/saying/controller/SayingController.java
+++ b/src/main/java/com/owori/domain/saying/controller/SayingController.java
@@ -35,7 +35,7 @@ public class SayingController {
      * @param request 수정된 서로에게 한마디 정보입니다.
      * @return 수정된 서로에게 한마디의 id가 반환됩니다.
      */
-    @PatchMapping
+    @PostMapping("/update")
     public ResponseEntity<IdResponse<UUID>> updateSaying(@RequestParam UUID sayingId, @RequestBody UpdateSayingRequest request) {
         return ResponseEntity.ok(sayingService.updateSaying(sayingId, request));
     }

--- a/src/main/java/com/owori/domain/saying/controller/SayingController.java
+++ b/src/main/java/com/owori/domain/saying/controller/SayingController.java
@@ -46,8 +46,9 @@ public class SayingController {
      * @return 삭제된 서로에게 한마디의 id가 반환됩니다.
      */
     @DeleteMapping
-    public ResponseEntity<IdResponse<UUID>> deleteSaying(@RequestParam UUID sayingId) {
-        return ResponseEntity.ok(sayingService.deleteSaying(sayingId));
+    public ResponseEntity<Void> deleteSaying(@RequestParam UUID sayingId) {
+        sayingService.deleteSaying(sayingId);
+        return ResponseEntity.ok().build();
     }
 
     /**

--- a/src/main/java/com/owori/domain/saying/entity/Saying.java
+++ b/src/main/java/com/owori/domain/saying/entity/Saying.java
@@ -29,7 +29,7 @@ public class Saying implements Auditable {
     @Column(nullable = false, length = 50)
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
@@ -44,4 +44,33 @@ public class Saying implements Auditable {
     @Embedded
     @Column(nullable = false)
     private BaseTime baseTime;
+
+    @Builder
+    public Saying(String content, Member member, List<Member> tagMembers) {
+        this.content = content;
+        this.member = member;
+        organize(tagMembers);
+        this.status = true;
+    }
+
+    public void update(String content, List<Member> tagMembers) {
+        this.content = content;
+        change(tagMembers);
+    }
+
+    private void organize(List<Member> tagMembers) {
+        this.tagMembers = tagMembers.stream()
+                .map(tagMember -> new SayingTagMember(this, tagMember))
+                .toList();
+    }
+
+    private void change(List<Member> tagMembers) {
+        // 기존에 있던거 삭제
+        this.tagMembers.forEach(SayingTagMember::delete);
+        // 새로운 태그된 멤버들 추가
+        this.tagMembers = tagMembers.stream()
+                .map(tagMember -> new SayingTagMember(this, tagMember))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/owori/domain/saying/entity/Saying.java
+++ b/src/main/java/com/owori/domain/saying/entity/Saying.java
@@ -37,9 +37,6 @@ public class Saying implements Auditable {
     @OneToMany(mappedBy = "saying", cascade = CascadeType.ALL)
     private List<SayingTagMember> tagMembers = new ArrayList<>();
 
-    @Column(nullable = false)
-    private Boolean status;
-
     @Setter
     @Embedded
     @Column(nullable = false)
@@ -50,7 +47,6 @@ public class Saying implements Auditable {
         this.content = content;
         this.member = member;
         organize(tagMembers);
-        this.status = true;
     }
 
     public void update(String content, List<Member> tagMembers) {

--- a/src/main/java/com/owori/domain/saying/entity/Saying.java
+++ b/src/main/java/com/owori/domain/saying/entity/Saying.java
@@ -37,7 +37,8 @@ public class Saying implements Auditable {
     @OneToMany(mappedBy = "saying", cascade = CascadeType.ALL)
     private List<SayingTagMember> tagMembers = new ArrayList<>();
 
-    private Boolean status;
+    @Column(nullable = false)
+    private Boolean status = Boolean.TRUE;
 
     @Setter
     @Embedded
@@ -48,7 +49,6 @@ public class Saying implements Auditable {
     public Saying(String content, Member member, List<Member> tagMembers) {
         this.content = content;
         this.member = member;
-        this.status = true;
         organize(tagMembers);
     }
 
@@ -71,5 +71,10 @@ public class Saying implements Auditable {
         this.tagMembers = tagMembers.stream()
                 .map(tagMember -> new SayingTagMember(this, tagMember))
                 .toList();
+    }
+
+    public void changeStatus() {
+        this.status = Boolean.FALSE;
+        this.delete();
     }
 }

--- a/src/main/java/com/owori/domain/saying/entity/Saying.java
+++ b/src/main/java/com/owori/domain/saying/entity/Saying.java
@@ -29,13 +29,15 @@ public class Saying implements Auditable {
     @Column(nullable = false, length = 50)
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
     // 태그 기능
     @OneToMany(mappedBy = "saying", cascade = CascadeType.ALL)
     private List<SayingTagMember> tagMembers = new ArrayList<>();
+
+    private Boolean status;
 
     @Setter
     @Embedded
@@ -46,6 +48,7 @@ public class Saying implements Auditable {
     public Saying(String content, Member member, List<Member> tagMembers) {
         this.content = content;
         this.member = member;
+        this.status = true;
         organize(tagMembers);
     }
 
@@ -60,6 +63,7 @@ public class Saying implements Auditable {
                 .toList();
     }
 
+
     private void change(List<Member> tagMembers) {
         // 기존에 있던거 삭제
         this.tagMembers.forEach(SayingTagMember::delete);
@@ -68,5 +72,4 @@ public class Saying implements Auditable {
                 .map(tagMember -> new SayingTagMember(this, tagMember))
                 .toList();
     }
-
 }

--- a/src/main/java/com/owori/domain/saying/entity/SayingTagMember.java
+++ b/src/main/java/com/owori/domain/saying/entity/SayingTagMember.java
@@ -4,10 +4,7 @@ import com.owori.domain.member.entity.Member;
 import com.owori.global.audit.AuditListener;
 import com.owori.global.audit.Auditable;
 import com.owori.global.audit.BaseTime;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Where;
 
@@ -27,12 +24,12 @@ public class SayingTagMember implements Auditable {
     private UUID id;
 
     // Saying
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "SAYING_ID")
     private Saying saying;
 
     // Tag된 Member
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
@@ -40,4 +37,11 @@ public class SayingTagMember implements Auditable {
     @Embedded
     @Column(nullable = false)
     private BaseTime baseTime;
+
+    @Builder
+    public SayingTagMember(Saying saying, Member member) {
+        this.saying = saying;
+        this.member = member;
+    }
+
 }

--- a/src/main/java/com/owori/domain/saying/exception/NoAuthorityUpdateException.java
+++ b/src/main/java/com/owori/domain/saying/exception/NoAuthorityUpdateException.java
@@ -1,0 +1,9 @@
+package com.owori.domain.saying.exception;
+
+public class NoAuthorityUpdateException extends IllegalArgumentException {
+    private static final String MESSAGE = "수정 권한이 없습니다.";
+
+    public NoAuthorityUpdateException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/owori/domain/saying/mapper/SayingMapper.java
+++ b/src/main/java/com/owori/domain/saying/mapper/SayingMapper.java
@@ -1,0 +1,18 @@
+package com.owori.domain.saying.mapper;
+
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.saying.entity.Saying;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SayingMapper {
+    public Saying toEntity(String content, Member member, List<Member> tagMembers) {
+        return Saying.builder()
+                .content(content)
+                .member(member)
+                .tagMembers(tagMembers)
+                .build();
+    }
+}

--- a/src/main/java/com/owori/domain/saying/mapper/SayingMapper.java
+++ b/src/main/java/com/owori/domain/saying/mapper/SayingMapper.java
@@ -1,10 +1,15 @@
 package com.owori.domain.saying.mapper;
 
 import com.owori.domain.member.entity.Member;
+import com.owori.domain.saying.dto.response.FindSayingByFamilyResponse;
 import com.owori.domain.saying.entity.Saying;
+import com.owori.domain.saying.entity.SayingTagMember;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Component
 public class SayingMapper {
@@ -14,5 +19,29 @@ public class SayingMapper {
                 .member(member)
                 .tagMembers(tagMembers)
                 .build();
+    }
+
+    public List<FindSayingByFamilyResponse> toResponseList(List<Saying> sayingList) {
+        return sayingList.stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private FindSayingByFamilyResponse toResponse(Saying saying) {
+        return FindSayingByFamilyResponse.builder()
+                .id(saying.getId())
+                .content(saying.getContent())
+                .memberId(saying.getMember().getId())
+                .tagMembersId(getTagMembersId(saying))
+                .updatedAt(getUpdatedAt(saying))
+                .build();
+    }
+
+    private LocalDateTime getUpdatedAt(Saying saying) {
+        return Optional.ofNullable(saying.getBaseTime().getUpdatedAt()).orElse(saying.getBaseTime().getCreatedAt());
+    }
+
+    private List<UUID> getTagMembersId(Saying saying) {
+        return saying.getTagMembers().stream().map(SayingTagMember::getMember).map(Member::getId).toList();
     }
 }

--- a/src/main/java/com/owori/domain/saying/repository/JpaSayingRepository.java
+++ b/src/main/java/com/owori/domain/saying/repository/JpaSayingRepository.java
@@ -1,10 +1,12 @@
 package com.owori.domain.saying.repository;
 
+import com.owori.domain.member.entity.Member;
 import com.owori.domain.saying.entity.Saying;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface JpaSayingRepository extends JpaRepository<Saying, UUID>, SayingRepository{
+
 
 }

--- a/src/main/java/com/owori/domain/saying/repository/SayingRepository.java
+++ b/src/main/java/com/owori/domain/saying/repository/SayingRepository.java
@@ -1,5 +1,6 @@
 package com.owori.domain.saying.repository;
 
+import com.owori.domain.member.entity.Member;
 import com.owori.domain.saying.entity.Saying;
 
 import java.util.Optional;
@@ -9,4 +10,6 @@ public interface SayingRepository {
 
     Optional<Saying> findById(UUID uuid);
     Saying save(Saying saying);
+    Saying findByMemberAndStatus(Member member, Boolean status);
+
 }

--- a/src/main/java/com/owori/domain/saying/repository/SayingRepository.java
+++ b/src/main/java/com/owori/domain/saying/repository/SayingRepository.java
@@ -10,6 +10,6 @@ public interface SayingRepository {
 
     Optional<Saying> findById(UUID uuid);
     Saying save(Saying saying);
-    Saying findByMemberAndStatus(Member member, Boolean status);
+    Optional<Saying> findByMemberAndStatus(Member member, Boolean status);
 
 }

--- a/src/main/java/com/owori/domain/saying/repository/SayingRepository.java
+++ b/src/main/java/com/owori/domain/saying/repository/SayingRepository.java
@@ -1,5 +1,12 @@
 package com.owori.domain.saying.repository;
 
+import com.owori.domain.saying.entity.Saying;
+
+import java.util.Optional;
+import java.util.UUID;
+
 public interface SayingRepository {
 
+    Optional<Saying> findById(UUID uuid);
+    Saying save(Saying saying);
 }

--- a/src/main/java/com/owori/domain/saying/service/SayingService.java
+++ b/src/main/java/com/owori/domain/saying/service/SayingService.java
@@ -1,38 +1,63 @@
 package com.owori.domain.saying.service;
 
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.service.AuthService;
+import com.owori.domain.member.service.MemberService;
 import com.owori.domain.saying.dto.request.AddSayingRequest;
 import com.owori.domain.saying.dto.request.UpdateSayingRequest;
 import com.owori.domain.saying.dto.response.FindSayingByFamilyResponse;
+import com.owori.domain.saying.entity.Saying;
+import com.owori.domain.saying.exception.NoAuthorityUpdateException;
+import com.owori.domain.saying.mapper.SayingMapper;
 import com.owori.domain.saying.repository.SayingRepository;
-import com.owori.global.audit.BaseTime;
 import com.owori.global.dto.IdResponse;
+import com.owori.global.exception.EntityNotFoundException;
+import com.owori.global.service.EntityLoader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class SayingService {
+public class SayingService implements EntityLoader<Saying, UUID> {
     private final SayingRepository sayingRepository;
+    private final MemberService memberService;
+    private final SayingMapper sayingMapper;
+    private final AuthService authService;
 
     public IdResponse<UUID> addSaying(AddSayingRequest request) {
-        return null; // todo: 로직 작성
+        Member member = authService.getLoginUser();
+        List<Member> tagMembers = memberService.findMembersByIds(request.getTagMembersId());
+        Saying newSaying = sayingRepository.save(sayingMapper.toEntity(request.getContent(), member, tagMembers));
+        return new IdResponse<>(newSaying.getId());
     }
 
     @Transactional
     public IdResponse<UUID> updateSaying(UUID sayingId, UpdateSayingRequest request) {
-        return null; // todo: 로직 작성
+        Member member = authService.getLoginUser();
+        Saying saying = loadEntity(sayingId);
+
+        // 서로에게 한마디 작성자와 현재 유저가 동일하지 않을 경우 예외처리
+        if(member != saying.getMember()) throw new NoAuthorityUpdateException();
+
+        // tagMemberIds를 통해 tagMembers 구하기
+        List<Member> tagMembers = memberService.findMembersByIds(request.getTagMembersId());
+
+        // 새로운 정보로 업데이트
+        saying.update(request.getContent(), tagMembers);
+
+        return new IdResponse<>(saying.getId());
     }
 
     @Transactional
-    public IdResponse<UUID> deleteSaying(UUID sayingId) {
-        return null; // todo: 로직 작성
+    public void deleteSaying(UUID sayingId) {
+        Saying saying = loadEntity(sayingId);
+        saying.delete();
     }
 
     public List<FindSayingByFamilyResponse> findSayingByFamily() {
@@ -41,5 +66,9 @@ public class SayingService {
         return null; // todo: 로직 작성
     }
 
+    @Override
+    public Saying loadEntity(UUID uuid) {
+        return sayingRepository.findById(uuid).orElseThrow(EntityNotFoundException::new);
+    }
 }
 

--- a/src/test/java/com/owori/domain/saying/SayingServiceTest/SayingServiceTest.java
+++ b/src/test/java/com/owori/domain/saying/SayingServiceTest/SayingServiceTest.java
@@ -1,0 +1,138 @@
+package com.owori.domain.saying.SayingServiceTest;
+
+import com.owori.domain.family.dto.request.FamilyRequest;
+import com.owori.domain.family.entity.Family;
+import com.owori.domain.family.repository.FamilyRepository;
+import com.owori.domain.family.service.FamilyService;
+import com.owori.domain.member.entity.AuthProvider;
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.entity.OAuth2Info;
+import com.owori.domain.member.service.AuthService;
+import com.owori.domain.saying.dto.request.AddSayingRequest;
+import com.owori.domain.saying.dto.request.UpdateSayingRequest;
+import com.owori.domain.saying.dto.response.FindSayingByFamilyResponse;
+import com.owori.domain.saying.entity.Saying;
+import com.owori.domain.saying.repository.SayingRepository;
+import com.owori.domain.saying.service.SayingService;
+import com.owori.global.dto.IdResponse;
+import com.owori.support.database.DatabaseTest;
+import com.owori.support.database.LoginTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DatabaseTest
+@DisplayName("Saying 서비스의")
+public class SayingServiceTest extends LoginTest {
+    @Autowired private SayingService sayingService;
+    @Autowired private SayingRepository sayingRepository;
+    @Autowired private FamilyService familyService;
+    @Autowired private FamilyRepository familyRepository;
+    @Autowired private AuthService authService;
+    @Autowired private EntityManager entityManager;
+
+    @Test
+    @DisplayName("서로에게 한마디 생성이 수행되는가")
+    void addSaying() {
+        // given
+        String content = "오늘 집에 안 들어가요";
+        AddSayingRequest request = new AddSayingRequest(content, List.of());
+
+        // when
+        IdResponse<UUID> response = sayingService.addSaying(request);
+
+        // then
+        Saying saying = sayingRepository.findById(response.getId()).orElseThrow();
+
+        assertThat(saying.getContent()).isEqualTo(content);
+        assertThat(saying.getMember()).isEqualTo(authService.getLoginUser());
+        assertThat(saying.getStatus()).isTrue();
+    }
+
+    @Test
+    @DisplayName("서로에게 한마디 수정이 수행되는가")
+    void updateSaying() {
+        // given
+        String content = "오늘 집에 일찍 가요";
+        UpdateSayingRequest request = new UpdateSayingRequest(content, List.of(UUID.randomUUID()));
+        Saying oldSaying = sayingRepository.save(new Saying("오늘 집에 안들어가요", authService.getLoginUser(), List.of()));
+
+
+        // when
+        IdResponse<UUID> response = sayingService.updateSaying(oldSaying.getId(), request);
+        Optional<Saying> newSaying = sayingRepository.findById(response.getId());
+
+        // then
+        assertThat(newSaying.get().getContent()).isEqualTo(content);
+    }
+
+    @Test
+    @DisplayName("서로에게 한마디 삭제가 수행되는가")
+    void deleteSaying() {
+        // given
+        Saying saying = sayingRepository.save(new Saying("오늘 집에 안들어감", authService.getLoginUser(), List.of()));
+
+        // when
+        sayingService.deleteSaying(saying.getId());
+        Optional<Saying> deleteSaying = sayingRepository.findById(saying.getId());
+
+        // then
+        assertThat(deleteSaying.get().getStatus()).isFalse();
+    }
+
+    @Test
+    @DisplayName("서로에게 한마디 가족별 조회가 수행되는가")
+    void findSayingByFamily() {
+        // given
+        // 가족 생성
+        String familyName = "오월이 가족";
+        String code = familyService.saveFamily(new FamilyRequest(familyName)).getInviteCode();
+
+        // 가족 구성원 생성
+        Member member1 = Member.builder().oAuth2Info(new OAuth2Info("123123", AuthProvider.APPLE)).build();
+        Member member2 = Member.builder().oAuth2Info(new OAuth2Info("123126", AuthProvider.APPLE)).build();
+        Member saveMember1 = memberRepository.save(member1);
+        Member saveMember2 = memberRepository.save(member2);
+
+        // 가족에 멤버 추가
+        Optional<Family> family = familyRepository.findByInviteCode(code);
+        if(family.isPresent()) {
+            family.get().addMember(saveMember1);
+            family.get().addMember(authService.getLoginUser());
+        }
+
+        // 서로에게 한마디 생성
+        Saying saying1 = sayingRepository.save(new Saying("오늘 집 안 감", authService.getLoginUser(), List.of()));
+        Saying saying2 = sayingRepository.save(new Saying("오늘 집 감", saveMember1, List.of()));
+        Saying saying3 = sayingRepository.save(new Saying("배고파", saveMember2, List.of()));
+
+        // when
+        entityManager.flush();
+        entityManager.clear();
+        List<FindSayingByFamilyResponse> responses = sayingService.findSayingByFamily();
+
+        // then
+        assertThat(responses.stream().map(FindSayingByFamilyResponse::getId)).hasSameElementsAs(List.of(saying1.getId(), saying2.getId()));
+    }
+
+    @Test
+    @DisplayName("id를 통한 조회가 수행되는가")
+    void loadEntity() {
+        // given
+        Saying saying = sayingRepository.save(new Saying("오늘 집에 안들어갈래", authService.getLoginUser(), List.of()));
+
+        // when
+        Saying result = sayingService.loadEntity(saying.getId());
+
+        // then
+        assertThat(saying).isEqualTo(result);
+    }
+}

--- a/src/test/java/com/owori/domain/saying/controller/SayingControllerTest.java
+++ b/src/test/java/com/owori/domain/saying/controller/SayingControllerTest.java
@@ -61,7 +61,7 @@ public class SayingControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("PATCH / saying 서로에게 한마디 수정 API 테스트")
+    @DisplayName("POST / saying 서로에게 한마디 수정 API 테스트")
     void updateSaying() throws Exception {
         // given
         UUID id = UUID.randomUUID();
@@ -73,7 +73,7 @@ public class SayingControllerTest extends RestDocsTest {
         // when
         ResultActions perform =
                 mockMvc.perform(
-                        patch("/saying")
+                        post("/saying/update")
                                 .param("sayingId", id.toString())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header("Authorization","Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")

--- a/src/test/java/com/owori/domain/saying/controller/SayingControllerTest.java
+++ b/src/test/java/com/owori/domain/saying/controller/SayingControllerTest.java
@@ -17,6 +17,7 @@ import static com.owori.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.owori.support.docs.ApiDocsUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -93,7 +94,7 @@ public class SayingControllerTest extends RestDocsTest {
         // given
         UUID id = UUID.randomUUID();
         IdResponse<UUID> expected = new IdResponse<>(id);
-        given(sayingService.deleteSaying(any())).willReturn(expected);
+        doNothing().when(sayingService).deleteSaying(any());
 
         // when
         ResultActions perform =


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. 서로에게 한마디 생성 API 작성
- 생성 API 서비스 코드 및 테스트 코드 작성
- 생성 시 이전 서로에게 한마디 삭제 수행
2. 서로에게 한마디 수정 API 작성
- 수정 API 서비스 코드 및 테스트 코드 작성
3. 서로에게 한마디 삭제 API 작성
- 삭제 API 서비스 코드 및 테스트 코드 작성
4. 서로에게 한마디 조회(가족 단위) API 작성
- 조회 API 서비스 코드 및 테스트 코드 작성
- 현재 로그인 유저 가족의 서로에게 한마디 정보 조회

* 멤버 id 리스트를 멤버 리스트로 반환해주는 함수 작성(MemberService, MemberRepository)
* Member, OAuth2Info 엔티티 isEqual 함수 변경
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?