### PR TITLE
[FEAT] update emotional badge api

### DIFF
--- a/src/docs/member.adoc
+++ b/src/docs/member.adoc
@@ -19,3 +19,6 @@ operation::update member profile[snippets='http-request,http-response']
 
 === 멤버 회원 탈퇴
 operation::delete member[snippets='http-request,http-response']
+
+=== 멤버 감정 뱃지 업데이트
+operation::update member emotional badge[snippets='http-request,http-response']

--- a/src/main/java/com/owori/domain/member/controller/MemberController.java
+++ b/src/main/java/com/owori/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.owori.domain.member.controller;
 
+import com.owori.domain.member.dto.request.EmotionalBadgeRequest;
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
 import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.request.MemberRequest;
@@ -76,6 +77,18 @@ public class MemberController {
     @DeleteMapping
     public ResponseEntity<Void> deleteMember() {
         memberService.deleteMember();
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 멤버 감정 뱃지 업데이트 컨트롤러입니다.
+     * 멤버의 감정 뱃지를 받아와 수정합니다.
+     * @param emotionalBadgeRequest 수정할 감정 뱃지 정보를 갖습니다.
+     * @return 바디로 response 하는 정보는 없습니다.
+     */
+    @PostMapping("/emotional-badge")
+    public ResponseEntity<Void> updateEmotionalBadge(@RequestBody EmotionalBadgeRequest emotionalBadgeRequest) {
+        memberService.updateEmotionalBadge(emotionalBadgeRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/owori/domain/member/dto/request/EmotionalBadgeRequest.java
+++ b/src/main/java/com/owori/domain/member/dto/request/EmotionalBadgeRequest.java
@@ -1,0 +1,13 @@
+package com.owori.domain.member.dto.request;
+
+import com.owori.domain.member.entity.EmotionalBadge;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionalBadgeRequest {
+    private EmotionalBadge emotionalBadge;
+}

--- a/src/main/java/com/owori/domain/member/entity/EmotionalBadge.java
+++ b/src/main/java/com/owori/domain/member/entity/EmotionalBadge.java
@@ -1,0 +1,25 @@
+package com.owori.domain.member.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum EmotionalBadge {
+    JOY("기뻐요"),
+    HAPPY("행복쓰"),
+    SO_HAPPY("엄청 행복쓰"),
+    LOVE("사랑해"),
+    SURRISED("놀람"),
+    INSIDIOUS("음흉쓰"),
+    NORMAL("보통"),
+    SLEEPY("졸림"),
+    FAINT("깨꼬닥"),
+    SULKY("삐졌어"),
+    SAD("슬퍼요"),
+    CRY("엉엉"),
+    GOOSE_BUMPS("소오오름"),
+    ANGRY("화남"),
+    VERY_ANGRY("매우 화남"),
+    NONE("선택 안함");
+
+    private final String toKorean;
+}

--- a/src/main/java/com/owori/domain/member/entity/Member.java
+++ b/src/main/java/com/owori/domain/member/entity/Member.java
@@ -48,6 +48,9 @@ public class Member implements Auditable {
     @Embedded
     private OAuth2Info oAuth2Info;
 
+    @Enumerated(EnumType.STRING)
+    private EmotionalBadge emotionalBadge = EmotionalBadge.NONE;
+
     @Setter
     @Embedded
     @Column(nullable = false)
@@ -115,5 +118,9 @@ public class Member implements Auditable {
     @Override
     public int hashCode() {
         return Objects.hash(oAuth2Info);
+    }
+
+    public void updateEmotionalBadge(EmotionalBadge emotionalBadge) {
+        this.emotionalBadge = emotionalBadge;
     }
 }

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.owori.domain.member.service;
 import com.owori.config.security.jwt.JwtToken;
 import com.owori.domain.member.client.KakaoMemberClient;
 import com.owori.domain.member.dto.client.KakaoMemberResponse;
+import com.owori.domain.member.dto.request.EmotionalBadgeRequest;
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
 import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.request.MemberRequest;
@@ -99,5 +100,10 @@ public class MemberService implements EntityLoader<Member, UUID> {
      */
     public List<Member> findMembersByIds(List<UUID> memberIds) {
         return memberRepository.findAllByIdIn(memberIds);
+    }
+
+    @Transactional
+    public void updateEmotionalBadge(EmotionalBadgeRequest emotionalBadgeRequest) {
+        authService.getLoginUser().updateEmotionalBadge(emotionalBadgeRequest.getEmotionalBadge());
     }
 }

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -98,12 +98,12 @@ public class MemberService implements EntityLoader<Member, UUID> {
      * @param memberIds 멤버 아이디 리스트
      * @return 멤버 리스트
      */
-    public List<Member> findMembersByIds(List<UUID> memberIds) {
+    public List<Member> findMembersByIds(final List<UUID> memberIds) {
         return memberRepository.findAllByIdIn(memberIds);
     }
 
     @Transactional
-    public void updateEmotionalBadge(EmotionalBadgeRequest emotionalBadgeRequest) {
+    public void updateEmotionalBadge(final EmotionalBadgeRequest emotionalBadgeRequest) {
         authService.getLoginUser().updateEmotionalBadge(emotionalBadgeRequest.getEmotionalBadge());
     }
 }

--- a/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
@@ -1,12 +1,14 @@
 package com.owori.domain.member.controller;
 
 import com.owori.config.security.jwt.JwtToken;
+import com.owori.domain.member.dto.request.EmotionalBadgeRequest;
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
 import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.response.MemberJwtResponse;
 import com.owori.domain.member.entity.AuthProvider;
 import com.owori.domain.member.entity.Color;
+import com.owori.domain.member.entity.EmotionalBadge;
 import com.owori.domain.member.service.MemberService;
 import com.owori.global.dto.ImageResponse;
 import com.owori.support.docs.RestDocsTest;
@@ -159,5 +161,28 @@ class MemberControllerTest extends RestDocsTest {
         //docs
         perform.andDo(print())
                 .andDo(document("delete member", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("멤버 감정뱃지 업데이트가 수행되는가")
+    void updateEmotionalBadge() throws Exception {
+        //given
+        doNothing().when(memberService).updateEmotionalBadge(any());
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/members/emotional-badge")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toRequestBody(new EmotionalBadgeRequest(EmotionalBadge.HAPPY)))
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString()));
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("update member emotional badge", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
@@ -1,9 +1,11 @@
 package com.owori.domain.member.service;
 
 import com.owori.domain.family.entity.Family;
+import com.owori.domain.member.dto.request.EmotionalBadgeRequest;
 import com.owori.domain.member.dto.request.MemberDetailsRequest;
 import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.entity.Color;
+import com.owori.domain.member.entity.EmotionalBadge;
 import com.owori.domain.member.entity.Member;
 import com.owori.global.exception.EntityNotFoundException;
 import com.owori.support.database.DatabaseTest;
@@ -116,5 +118,21 @@ class MemberServiceTest extends LoginTest {
 
         //then
         assertThrows(EntityNotFoundException.class, () -> memberService.loadEntity(id));
+    }
+
+    @Test
+    @DisplayName("감정 뱃지 업데이트가 수행되는가")
+    void updateEmotionalBadge() {
+        //given
+        EmotionalBadge before = authService.getLoginUser().getEmotionalBadge();
+
+        //when
+        EmotionalBadge soHappy = EmotionalBadge.SO_HAPPY;
+        memberService.updateEmotionalBadge(new EmotionalBadgeRequest(soHappy));
+        em.flush();
+        em.clear();
+
+        //then
+        assertThat(authService.getLoginUser().getEmotionalBadge()).isEqualTo(soHappy).isNotEqualTo(before);
     }
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 감정뱃지 업데이트 api

### 특이사항
- 감정 뱃지를 없애려면 emotional_badge 값을 NONE으로 주면 됩니다.
- 초기 값 또한 NONE
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?