### PR TITLE
[FEAT] 이야기 검색 API, API Docs 추가

### DIFF
--- a/src/docs/story.adoc
+++ b/src/docs/story.adoc
@@ -22,3 +22,6 @@ operation::find story by eventAt[snippets='http-request,http-response']
 
 === 이야기 상세 조회
 operation::find story[snippets='http-request,http-response']
+
+=== 이야기 검색
+operation::find story by search[snippets='http-request,http-response']

--- a/src/main/java/com/owori/domain/comment/entity/TimesAgo.java
+++ b/src/main/java/com/owori/domain/comment/entity/TimesAgo.java
@@ -24,17 +24,15 @@ public enum TimesAgo {
     public static String of(LocalDateTime localDateTime) {
         int diffTime = (int) localDateTime.until(LocalDateTime.now(), ChronoUnit.SECONDS);
 
-        TimesAgo unit = Arrays.stream(TimesAgo.values())
+        return Arrays.stream(TimesAgo.values())
                 .filter(timesAgo -> timesAgo.timeToSecond.test(diffTime))
-                .findAny()
-                .orElse(null);
+                .map(timesAgo -> {
+                    long value = diffTime / timesAgo.getChronoUnit().getDuration().getSeconds();
+                    return value + timesAgo.getMessage();
+                })
+                .findFirst()
+                .orElseGet(() -> localDateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd")));
 
-        if (unit != null) {
-            long value = diffTime / unit.getChronoUnit().getDuration().getSeconds();
-            return value + unit.getMessage();
-        } else {
-            return localDateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"));
-        }
     }
 }
 

--- a/src/main/java/com/owori/domain/story/controller/StoryController.java
+++ b/src/main/java/com/owori/domain/story/controller/StoryController.java
@@ -1,6 +1,7 @@
 package com.owori.domain.story.controller;
 
 import com.owori.domain.story.dto.request.PostStoryRequest;
+import com.owori.domain.story.dto.request.SearchStoryRequest;
 import com.owori.domain.story.dto.response.FindAllStoryGroupResponse;
 import com.owori.domain.story.dto.response.FindStoryResponse;
 import com.owori.domain.story.service.FacadeService;
@@ -52,16 +53,15 @@ public class StoryController {
 
     /**
      * 이야기 검색을 위한 컨트롤러입니다.
-     * @param keyword 검색어입니다.
+     * @param request 검색어입니다.
      * @param pageable
-     * @return 전체 조회 dto가 반환됩니다.
+     * @return 검색 결과 dto가 반환됩니다.
      */
     @GetMapping( "/search")
     public ResponseEntity<FindAllStoryGroupResponse> findStoryBySearch(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
-                                                                       @RequestParam String keyword,
-                                                                       @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed){
+                                                                       @ModelAttribute SearchStoryRequest request){
 
-        return ResponseEntity.ok(storyService.findStoryBySearch(keyword, pageable, lastViewed));
+        return ResponseEntity.ok(storyService.findStoryBySearch(request.getKeyword(), pageable, request.getLastViewed()));
     }
 
     /**

--- a/src/main/java/com/owori/domain/story/controller/StoryController.java
+++ b/src/main/java/com/owori/domain/story/controller/StoryController.java
@@ -51,6 +51,20 @@ public class StoryController {
     }
 
     /**
+     * 이야기 검색을 위한 컨트롤러입니다.
+     * @param keyword 검색어입니다.
+     * @param pageable
+     * @return 전체 조회 dto가 반환됩니다.
+     */
+    @GetMapping( "/search")
+    public ResponseEntity<FindAllStoryGroupResponse> findStoryBySearch(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
+                                                                       @RequestParam String keyword,
+                                                                       @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed){
+
+        return ResponseEntity.ok(storyService.findStoryBySearch(keyword, pageable, lastViewed));
+    }
+
+    /**
      * 이야기를 상세 조회를 위한 컨트롤러입니다.
      * @param storyId 조회할 story의 id 값 입니다.
      * @return 상세 조회 dto가 반환됩니다.

--- a/src/main/java/com/owori/domain/story/dto/request/SearchStoryRequest.java
+++ b/src/main/java/com/owori/domain/story/dto/request/SearchStoryRequest.java
@@ -2,6 +2,7 @@ package com.owori.domain.story.dto.request;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.Size;
 import java.time.LocalDate;
@@ -13,5 +14,6 @@ public class SearchStoryRequest {
     @Size(message = "검색어를 2글자 이상 입력해주세요.", min = 2)
     private String keyword;
 
-    LocalDate lastViewed;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate lastViewed;
 }

--- a/src/main/java/com/owori/domain/story/dto/request/SearchStoryRequest.java
+++ b/src/main/java/com/owori/domain/story/dto/request/SearchStoryRequest.java
@@ -1,0 +1,17 @@
+package com.owori.domain.story.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Size;
+import java.time.LocalDate;
+
+@Setter
+@Getter
+public class SearchStoryRequest {
+
+    @Size(message = "검색어를 2글자 이상 입력해주세요.", min = 2)
+    private String keyword;
+
+    LocalDate lastViewed;
+}

--- a/src/main/java/com/owori/domain/story/exception/SearchKeywordException.java
+++ b/src/main/java/com/owori/domain/story/exception/SearchKeywordException.java
@@ -1,0 +1,7 @@
+package com.owori.domain.story.exception;
+
+public class SearchKeywordException extends IllegalArgumentException{
+    private static final String MESSAGE = "검색어는 2글자 이상 입력해주세요.";
+
+    public SearchKeywordException() { super(MESSAGE); }
+}

--- a/src/main/java/com/owori/domain/story/exception/SearchKeywordException.java
+++ b/src/main/java/com/owori/domain/story/exception/SearchKeywordException.java
@@ -1,7 +1,0 @@
-package com.owori.domain.story.exception;
-
-public class SearchKeywordException extends IllegalArgumentException{
-    private static final String MESSAGE = "검색어는 2글자 이상 입력해주세요.";
-
-    public SearchKeywordException() { super(MESSAGE); }
-}

--- a/src/main/java/com/owori/domain/story/repository/StoryRepositoryCustom.java
+++ b/src/main/java/com/owori/domain/story/repository/StoryRepositoryCustom.java
@@ -9,4 +9,5 @@ import java.time.LocalDate;
 
 public interface StoryRepositoryCustom {
     Slice<Story> findAllStory(Pageable pageable, Family family, LocalDate date);
+    Slice<Story> findStoryBySearch(Pageable pageable, String keyword, Family family, LocalDate date);
 }

--- a/src/main/java/com/owori/domain/story/service/StoryService.java
+++ b/src/main/java/com/owori/domain/story/service/StoryService.java
@@ -9,6 +9,7 @@ import com.owori.domain.story.dto.request.PostStoryRequest;
 import com.owori.domain.story.dto.response.*;
 import com.owori.domain.story.entity.Story;
 import com.owori.domain.story.exception.InvalidUserException;
+import com.owori.domain.story.exception.SearchKeywordException;
 import com.owori.domain.story.mapper.StoryMapper;
 import com.owori.domain.story.repository.StoryRepository;
 import com.owori.global.dto.IdResponse;
@@ -85,6 +86,16 @@ public class StoryService implements EntityLoader<Story, UUID> {
         imageService.removeImages(story); // 이미지 삭제
         story.getHearts().stream().forEach(story::removeHeart); // 좋아요 삭제
         story.delete(); // 스토리 삭제
+    }
+
+    public FindAllStoryGroupResponse findStoryBySearch(String keyword, Pageable pageable, LocalDate lastViewed) {
+        if(keyword.length() < 2) { throw new SearchKeywordException(); }
+
+        Family family = authService.getLoginUser().getFamily();
+        Slice<Story> storyBySearch = storyRepository.findStoryBySearch(pageable, keyword, family, lastViewed);
+        List<FindAllStoryResponse> stories = storyBySearch.getContent().stream().map(story -> storyMapper.toFindAllStoryDto(story)).toList();
+
+        return new FindAllStoryGroupResponse(stories, storyBySearch.hasNext());
     }
 
     @Override

--- a/src/main/java/com/owori/domain/story/service/StoryService.java
+++ b/src/main/java/com/owori/domain/story/service/StoryService.java
@@ -9,7 +9,6 @@ import com.owori.domain.story.dto.request.PostStoryRequest;
 import com.owori.domain.story.dto.response.*;
 import com.owori.domain.story.entity.Story;
 import com.owori.domain.story.exception.InvalidUserException;
-import com.owori.domain.story.exception.SearchKeywordException;
 import com.owori.domain.story.mapper.StoryMapper;
 import com.owori.domain.story.repository.StoryRepository;
 import com.owori.global.dto.IdResponse;
@@ -89,8 +88,6 @@ public class StoryService implements EntityLoader<Story, UUID> {
     }
 
     public FindAllStoryGroupResponse findStoryBySearch(String keyword, Pageable pageable, LocalDate lastViewed) {
-        if(keyword.length() < 2) { throw new SearchKeywordException(); }
-
         Family family = authService.getLoginUser().getFamily();
         Slice<Story> storyBySearch = storyRepository.findStoryBySearch(pageable, keyword, family, lastViewed);
         List<FindAllStoryResponse> stories = storyBySearch.getContent().stream().map(story -> storyMapper.toFindAllStoryDto(story)).toList();

--- a/src/test/java/com/owori/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/owori/domain/comment/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.owori.domain.comment.service;
 import com.owori.domain.comment.dto.request.AddCommentRequest;
 import com.owori.domain.comment.dto.request.UpdateCommentRequest;
 import com.owori.domain.comment.entity.Comment;
+import com.owori.domain.comment.entity.TimesAgo;
 import com.owori.domain.comment.repository.CommentRepository;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,6 +125,36 @@ public class CommentServiceTest extends LoginTest {
         //then
         Comment updateComment = commentRepository.findById(comment.getId()).get();
         assertThat(updateComment.getContent()).isEqualTo(content);
+
+    }
+
+
+    @Test
+    @DisplayName("time ago enum class 가 제대로 실행되는가")
+    void findTimeAgo() {
+
+        // 50초 전
+        String second = TimesAgo.of(LocalDateTime.now().minusSeconds(50));
+
+        // 10분 전
+        String minute = TimesAgo.of(LocalDateTime.now().minusMinutes(10));
+
+        // 2시간 전
+        String hour = TimesAgo.of(LocalDateTime.now().minusHours(2));
+
+        // 6일 전
+        String day = TimesAgo.of(LocalDateTime.now().minusDays(6));
+
+        // n개월 전
+        String month = TimesAgo.of(LocalDateTime.of(2022,3,2,3,1,2,3));
+
+
+        //then
+        assertThat(second).isEqualTo("50초 전");
+        assertThat(minute).isEqualTo("10분 전");
+        assertThat(hour).isEqualTo("2시간 전");
+        assertThat(day).isEqualTo("6일 전");
+        assertThat(month).isEqualTo("22.03.02");
 
     }
 

--- a/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
+++ b/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
@@ -1,7 +1,6 @@
 package com.owori.domain.story.controller;
 
 import com.owori.domain.comment.dto.response.CommentResponse;
-import com.owori.domain.member.service.AuthService;
 import com.owori.domain.story.dto.request.PostStoryRequest;
 import com.owori.domain.story.dto.response.*;
 import com.owori.domain.story.service.FacadeService;
@@ -35,7 +34,6 @@ public class StoryControllerTest extends RestDocsTest{
 
     @MockBean private StoryService storyService;
     @MockBean private FacadeService facadeService;
-    @MockBean private AuthService authService;
 
     @Test
     @DisplayName("POST /stories 이야기 등록 API 테스트")
@@ -96,10 +94,10 @@ public class StoryControllerTest extends RestDocsTest{
     void findAllStoryByEventAt() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(
-                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)),
-                new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
-                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)));
+                new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)));
 
         FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
         given(storyService.findAllStory(any(),any())).willReturn(findAllStoryGroupResponse);
@@ -128,10 +126,10 @@ public class StoryControllerTest extends RestDocsTest{
     void findAllStoryByCreatedAt() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(
-                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
+                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)),
                 new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)));
+                new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
+                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)));
 
         FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
         given(storyService.findAllStory(any(),any())).willReturn(findAllStoryGroupResponse);
@@ -210,5 +208,38 @@ public class StoryControllerTest extends RestDocsTest{
         //docs
         perform.andDo(print())
                 .andDo(document("remove story", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("GET /stories 검섹 API 테스트")
+    void findStoryBySearch() throws Exception {
+        //given
+        List<FindAllStoryResponse> response = List.of(
+                new FindAllStoryResponse(UUID.randomUUID(),"룰루랄라", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03)),
+                new FindAllStoryResponse(UUID.randomUUID(),"생일잔치", "못난이 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 1, 0, "허망고", LocalDate.of(2011, 02, 01), LocalDate.of(2011, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"쇼핑 데이 with 못난이", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "못난이", LocalDate.of(2010, 02, 01), LocalDate.of(2022, 12, 03)));
+
+        FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, false);
+        given(storyService.findStoryBySearch(any(),any(), any())).willReturn(findAllStoryGroupResponse);
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/stories/search")
+                                .param("keyword", "못난이")
+                                .param("lastViewed","2023-08-31")
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString())
+                                .characterEncoding("UTF-8")
+                                .contentType(MediaType.APPLICATION_JSON)
+                );
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("find story by search", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
+++ b/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
@@ -211,7 +211,7 @@ public class StoryControllerTest extends RestDocsTest{
     }
 
     @Test
-    @DisplayName("GET /stories 검섹 API 테스트")
+    @DisplayName("GET /stories 검색 API 테스트")
     void findStoryBySearch() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(

--- a/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
+++ b/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
@@ -8,6 +8,7 @@ import com.owori.domain.heart.entity.Heart;
 import com.owori.domain.heart.repository.HeartRepository;
 import com.owori.domain.image.entity.Image;
 import com.owori.domain.image.repository.ImageRepository;
+import com.owori.domain.member.entity.Color;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
 import com.owori.domain.story.dto.request.PostStoryRequest;
@@ -215,4 +216,31 @@ public class StoryServiceTest extends LoginTest {
         assertThrows(EntityNotFoundException.class, () -> storyService.loadEntity(story.getId()));
 
     }
+
+    @Test
+    @DisplayName("이야기 검색이 수행되는가")
+    void findStoryBySearch() {
+        //given
+        Member member = authService.getLoginUser();
+        Family family = new Family("우리집", member, "code");
+        Story story = new Story("기다리고 기다리던 하루", "내용", LocalDate.parse("2017-12-25"), LocalDate.parse("2017-12-30"), member);
+        Story story2 = new Story("제목2", "내용", LocalDate.parse("2015-12-25"), LocalDate.parse("2015-12-30"), member);
+        Story story3 = new Story("제목3", "내용 기다리고", LocalDate.parse("2015-12-25"), LocalDate.parse("2015-12-30"), member);
+
+        familyRepository.save(family);
+        member.updateProfile("파인애플",LocalDate.of(2000,04,22), Color.PINK);
+        storyRepository.save(story);
+        storyRepository.save(story2);
+        storyRepository.save(story3);
+
+        //when
+        FindAllStoryGroupResponse response = storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("createdAt")), null);
+
+        //then
+        assertThat(response.getStories().size()).isEqualTo(2);
+        assertThat(response.getStories().get(0).getContents()).isEqualTo("내용 기다리고");
+        assertThat(response.getStories().get(0).getWriter()).isEqualTo("파인애플");
+        assertThat(response.getStories().get(1).getTitle()).isEqualTo("기다리고 기다리던 하루");
+    }
+
 }

--- a/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
+++ b/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
@@ -148,35 +148,6 @@ public class StoryServiceTest extends LoginTest {
     }
 
     @Test
-    @DisplayName("time ago enum class 가 제대로 실행되는가")
-    void findTimeAgo() {
-
-        // 50초 전
-        String second = TimesAgo.of(LocalDateTime.now().minusSeconds(50));
-
-        // 10분 전
-        String minute = TimesAgo.of(LocalDateTime.now().minusMinutes(10));
-
-        // 2시간 전
-        String hour = TimesAgo.of(LocalDateTime.now().minusHours(2));
-
-        // 6일 전
-        String day = TimesAgo.of(LocalDateTime.now().minusDays(6));
-
-        // n개월 전
-        String month = TimesAgo.of(LocalDateTime.of(2022,3,2,3,1,2,3));
-
-
-        //then
-        assertThat(second).isEqualTo("50초 전");
-        assertThat(minute).isEqualTo("10분 전");
-        assertThat(hour).isEqualTo("2시간 전");
-        assertThat(day).isEqualTo("6일 전");
-        assertThat(month).isEqualTo("22.03.02");
-
-    }
-
-    @Test
     @DisplayName("이야기 수정이 수행되는가")
     void updateStory() {
         //given


### PR DESCRIPTION
## 이슈 번호
Closes #51 

## 추가/수정한 기능 설명
- 이야기 검색 API 구현
- 해당 API Docs에 추가
<br>

## 🧐 고민
`최근 검색어`를 조회하는 API 작업이 필요한데, entity를 따로 만들어야겠죠?
<br>

## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?