### PR TITLE
[FEAT] 디데이 조회 API

### DIFF
--- a/src/docs/schedule.adoc
+++ b/src/docs/schedule.adoc
@@ -15,4 +15,7 @@ operation::update schedule[snippets='http-request,http-response']
 operation::delete schedule[snippets='http-request,http-response']
 
 === 일정 월별 조회
-operation::find schedule by month[snippets='http-request,http-response']
+operation::find schedules by month[snippets='http-request,http-response']
+
+=== 가족별 디데이 조회
+operation::find schedules by family[snippets='http-request,http-response']

--- a/src/main/java/com/owori/domain/saying/entity/Saying.java
+++ b/src/main/java/com/owori/domain/saying/entity/Saying.java
@@ -30,7 +30,7 @@ public class Saying implements Auditable {
     private String content;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "MEMBER_ID")
+    @JoinColumn
     private Member member;
 
     // 태그 기능

--- a/src/main/java/com/owori/domain/saying/entity/SayingTagMember.java
+++ b/src/main/java/com/owori/domain/saying/entity/SayingTagMember.java
@@ -25,12 +25,12 @@ public class SayingTagMember implements Auditable {
 
     // Saying
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "SAYING_ID")
+    @JoinColumn
     private Saying saying;
 
     // Tag 된 Member
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "MEMBER_ID")
+    @JoinColumn
     private Member member;
 
     @Setter

--- a/src/main/java/com/owori/domain/saying/service/SayingService.java
+++ b/src/main/java/com/owori/domain/saying/service/SayingService.java
@@ -46,11 +46,10 @@ public class SayingService implements EntityLoader<Saying, UUID> {
 
     @Transactional
     public IdResponse<UUID> updateSaying(UUID sayingId, UpdateSayingRequest request) {
-        Member member = authService.getLoginUser();
         Saying saying = loadEntity(sayingId);
 
         // 서로에게 한마디 작성자와 현재 유저가 동일하지 않을 경우 예외처리
-        if(!member.equals(saying.getMember())) throw new NoAuthorityException();
+        if(!authService.getLoginUser().equals(saying.getMember())) throw new NoAuthorityException();
 
         // tagMemberIds 를 통해 tagMembers 구하기
         List<Member> tagMembers = memberService.findMembersByIds(request.getTagMembersId());
@@ -69,8 +68,7 @@ public class SayingService implements EntityLoader<Saying, UUID> {
     }
 
     public List<FindSayingByFamilyResponse> findSayingByFamily() {
-        Member nowMember = authService.getLoginUser();
-        Family family = nowMember.getFamily();
+        Family family = authService.getLoginUser().getFamily();
 
         List<Saying> sayingList = family.getMembers().stream()
                 .map(member -> sayingRepository.findByMemberAndModifiable(member, true))

--- a/src/main/java/com/owori/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/owori/domain/schedule/controller/ScheduleController.java
@@ -65,9 +65,13 @@ public class ScheduleController {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * 가족단위 디데이 조회 컨트롤러입니다.
+     * @return 디데이 옵션이 켜진 일정 반환
+     */
 
     @GetMapping("/dday")
-    public ResponseEntity<List<FindDdayByFamilyResponse>> findDdayByFamily() {
-        return ResponseEntity.ok(scheduleService.findDdayByFamily());
+    public ResponseEntity<List<FindDdayByFamilyResponse>> findDDayByFamily() {
+        return ResponseEntity.ok(scheduleService.findDDayByFamily());
     }
 }

--- a/src/main/java/com/owori/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/owori/domain/schedule/controller/ScheduleController.java
@@ -2,7 +2,7 @@ package com.owori.domain.schedule.controller;
 
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
 import com.owori.domain.schedule.dto.request.UpdateScheduleRequest;
-import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
+import com.owori.domain.schedule.dto.response.FindDDayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.service.ScheduleService;
 import com.owori.global.dto.IdResponse;
@@ -71,7 +71,7 @@ public class ScheduleController {
      */
 
     @GetMapping("/dday")
-    public ResponseEntity<List<FindDdayByFamilyResponse>> findDDayByFamily() {
+    public ResponseEntity<List<FindDDayByFamilyResponse>> findDDayByFamily() {
         return ResponseEntity.ok(scheduleService.findDDayByFamily());
     }
 }

--- a/src/main/java/com/owori/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/owori/domain/schedule/controller/ScheduleController.java
@@ -2,6 +2,7 @@ package com.owori.domain.schedule.controller;
 
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
 import com.owori.domain.schedule.dto.request.UpdateScheduleRequest;
+import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.service.ScheduleService;
 import com.owori.global.dto.IdResponse;
@@ -51,5 +52,10 @@ public class ScheduleController {
     @GetMapping("/month")
     public ResponseEntity<List<FindScheduleByMonthResponse>> findScheduleByMonth(@RequestParam String yearMonth) {
         return ResponseEntity.ok(scheduleService.findScheduleByMonth(yearMonth));
+    }
+
+    @GetMapping("/dday")
+    public ResponseEntity<List<FindDdayByFamilyResponse>> findDdayByFamily() {
+        return ResponseEntity.ok(scheduleService.findDdayByFamily());
     }
 }

--- a/src/main/java/com/owori/domain/schedule/dto/response/FindDDayByFamilyResponse.java
+++ b/src/main/java/com/owori/domain/schedule/dto/response/FindDDayByFamilyResponse.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class FindDdayByFamilyResponse {
+public class FindDDayByFamilyResponse {
     private UUID id;
     private String title;
     private LocalDate startDate;

--- a/src/main/java/com/owori/domain/schedule/dto/response/FindDdayByFamilyResponse.java
+++ b/src/main/java/com/owori/domain/schedule/dto/response/FindDdayByFamilyResponse.java
@@ -21,10 +21,11 @@ public class FindDdayByFamilyResponse {
     private String title;
     private LocalDate startDate;
     private LocalDate endDate;
+    private String dDay;
     private ScheduleType scheduleType;
-    private UUID memberId;
+    private String memberNickname;
     private Color color;
     private Boolean dDayOption;
-    private List<Alarm> alarmsOptions;
+    private List<Alarm> alarmOptions;
 
 }

--- a/src/main/java/com/owori/domain/schedule/dto/response/FindDdayByFamilyResponse.java
+++ b/src/main/java/com/owori/domain/schedule/dto/response/FindDdayByFamilyResponse.java
@@ -1,0 +1,30 @@
+package com.owori.domain.schedule.dto.response;
+
+import com.owori.domain.member.entity.Color;
+import com.owori.domain.schedule.entity.Alarm;
+import com.owori.domain.schedule.entity.ScheduleType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FindDdayByFamilyResponse {
+    private UUID id;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private ScheduleType scheduleType;
+    private UUID memberId;
+    private Color color;
+    private Boolean dDayOption;
+    private List<Alarm> alarmsOptions;
+
+}

--- a/src/main/java/com/owori/domain/schedule/dto/response/FindScheduleByMonthResponse.java
+++ b/src/main/java/com/owori/domain/schedule/dto/response/FindScheduleByMonthResponse.java
@@ -22,7 +22,7 @@ public class FindScheduleByMonthResponse {
     private LocalDate startDate;
     private LocalDate endDate;
     private ScheduleType scheduleType;
-    private UUID memberId;
+    private String memberNickname;
     private Color color;
     private Boolean dDayOption;
     private List<Alarm> alarmOptions;

--- a/src/main/java/com/owori/domain/schedule/entity/Alarm.java
+++ b/src/main/java/com/owori/domain/schedule/entity/Alarm.java
@@ -11,7 +11,7 @@ public enum Alarm {
 
     private final String toKorean;
 
-    private Alarm(String alarmType) {
+    Alarm(String alarmType) {
         this.toKorean = alarmType;
     }
 }

--- a/src/main/java/com/owori/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/owori/domain/schedule/entity/Schedule.java
@@ -39,7 +39,7 @@ public class Schedule implements Auditable {
     private ScheduleType scheduleType;
 
     // 개인이라면 색을 받아오기 위해서 생성자 저장
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn
     private Member member;
 

--- a/src/main/java/com/owori/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/owori/domain/schedule/entity/Schedule.java
@@ -40,7 +40,7 @@ public class Schedule implements Auditable {
 
     // 개인이라면 색을 받아오기 위해서 생성자 저장
     @ManyToOne
-    @JoinColumn(name = "MEMBER_ID")
+    @JoinColumn
     private Member member;
 
     private Boolean dDayOption;

--- a/src/main/java/com/owori/domain/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/owori/domain/schedule/mapper/ScheduleMapper.java
@@ -2,11 +2,15 @@ package com.owori.domain.schedule.mapper;
 
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
+import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.entity.Schedule;
+import com.owori.domain.schedule.entity.ScheduleType;
+import org.joda.time.Days;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 
 @Component
@@ -23,25 +27,55 @@ public class ScheduleMapper {
                 .build();
     }
 
-    public List<FindScheduleByMonthResponse> toResponseList(List<Schedule> schedules) {
+    public List<FindScheduleByMonthResponse> toMonthResponseList(List<Schedule> schedules) {
         return schedules.stream()
-                .map(this::toResponse)
+                .map(this::toMonthResponse)
                 .toList();
     }
 
-    private FindScheduleByMonthResponse toResponse(Schedule schedule) {
+    public List<FindDdayByFamilyResponse> toDDayResponseList(List<Schedule> schedules) {
+        return schedules.stream()
+                .map(schedule -> toDDayResponse(schedule, toDDay(schedule.getStartDate())))
+                .toList();
+    }
+
+    private FindScheduleByMonthResponse toMonthResponse(Schedule schedule) {
         return FindScheduleByMonthResponse.builder()
                 .id(schedule.getId())
                 .title(schedule.getTitle())
                 .startDate(schedule.getStartDate())
                 .endDate(schedule.getEndDate())
-                .memberId(schedule.getMember().getId())
+                .scheduleType(schedule.getScheduleType())
+                .memberNickname( schedule.getMember().getNickname())
                 .color(schedule.getMember().getColor())
                 .dDayOption(schedule.getDDayOption())
                 .alarmOptions(schedule.getAlarmList())
                 .build();
     }
 
+    private FindDdayByFamilyResponse toDDayResponse(Schedule schedule, String dDay) {
+        return FindDdayByFamilyResponse.builder()
+                .id(schedule.getId())
+                .title(schedule.getTitle())
+                .startDate(schedule.getStartDate())
+                .endDate(schedule.getEndDate())
+                .dDay(dDay)
+                .scheduleType(schedule.getScheduleType())
+                .memberNickname(schedule.getMember().getNickname())
+                .color(schedule.getMember().getColor())
+                .dDayOption(schedule.getDDayOption())
+                .alarmOptions(schedule.getAlarmList())
+                .build();
+    }
+
+    private String toDDay(LocalDate toDate) {
+        int days = Period.between(LocalDate.now(), toDate).getDays();
+        String dDay;
+        if(days == 0) dDay = "D-DAY";
+        else dDay = "D-" + days;
+
+        return dDay;
+    }
     public LocalDate toFirstDate(String yearMonth) {
         return LocalDate.parse(yearMonth + "-01");
     }

--- a/src/main/java/com/owori/domain/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/owori/domain/schedule/mapper/ScheduleMapper.java
@@ -2,11 +2,9 @@ package com.owori.domain.schedule.mapper;
 
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
-import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
+import com.owori.domain.schedule.dto.response.FindDDayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.entity.Schedule;
-import com.owori.domain.schedule.entity.ScheduleType;
-import org.joda.time.Days;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -33,7 +31,7 @@ public class ScheduleMapper {
                 .toList();
     }
 
-    public List<FindDdayByFamilyResponse> toDDayResponseList(List<Schedule> schedules) {
+    public List<FindDDayByFamilyResponse> toDDayResponseList(List<Schedule> schedules) {
         return schedules.stream()
                 .map(schedule -> toDDayResponse(schedule, toDDay(schedule.getStartDate())))
                 .toList();
@@ -53,8 +51,8 @@ public class ScheduleMapper {
                 .build();
     }
 
-    private FindDdayByFamilyResponse toDDayResponse(Schedule schedule, String dDay) {
-        return FindDdayByFamilyResponse.builder()
+    private FindDDayByFamilyResponse toDDayResponse(Schedule schedule, String dDay) {
+        return FindDDayByFamilyResponse.builder()
                 .id(schedule.getId())
                 .title(schedule.getTitle())
                 .startDate(schedule.getStartDate())
@@ -70,11 +68,8 @@ public class ScheduleMapper {
 
     private String toDDay(LocalDate toDate) {
         int days = Period.between(LocalDate.now(), toDate).getDays();
-        String dDay;
-        if(days == 0) dDay = "D-DAY";
-        else dDay = "D-" + days;
-
-        return dDay;
+        if(days == 0) return "D-DAY";
+        return "D-" + days;
     }
     public LocalDate toFirstDate(String yearMonth) {
         return LocalDate.parse(yearMonth + "-01");

--- a/src/main/java/com/owori/domain/schedule/repository/JpaScheduleRepository.java
+++ b/src/main/java/com/owori/domain/schedule/repository/JpaScheduleRepository.java
@@ -12,4 +12,7 @@ public interface JpaScheduleRepository extends JpaRepository<Schedule, Long>, Sc
 
     @Query("select s from Schedule s where s.member = :member and ((s.startDate between :startDate and :endDate) or (s.endDate between :startDate and :endDate))")
     List<Schedule> findAllByMonth(Member member, LocalDate startDate, LocalDate endDate);
+
+    @Query("select s from Schedule s where s.member = :member and s.dDayOption = :dDayOption and s.startDate >= :nowDate")
+    List<Schedule> findAllByMember(Member member, Boolean dDayOption, LocalDate nowDate);
 }

--- a/src/main/java/com/owori/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/owori/domain/schedule/repository/ScheduleRepository.java
@@ -15,4 +15,8 @@ public interface ScheduleRepository {
 
     // 멤버와 웗 시작일과 종료일 받아서 일정 넘겨주기
     List<Schedule> findAllByMonth(Member member, LocalDate startDate, LocalDate endDate);
+
+    // 멤버와 디데이옵션을 통해서 오늘 이후 일정 넘겨주기
+    List<Schedule> findAllByMember(Member member, Boolean dDayOption, LocalDate nowDate);
+
 }

--- a/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
@@ -38,10 +38,8 @@ public class ScheduleService implements EntityLoader<Schedule, UUID> {
     public IdResponse<UUID> updateSchedule(UUID scheduleId, UpdateScheduleRequest updateScheduleRequest) {
         // id 값으로 일정 찾기
         Schedule schedule = loadEntity(scheduleId);
-        // 로그인 중인 유저 받기
-        Member member = authService.getLoginUser();
         // 현재 일정이 개인 일정이고 현재 사용자와 생성자가 다를 경우 예외처리
-        if(schedule.getScheduleType().equals(ScheduleType.INDIVIDUAL) && !member.equals(schedule.getMember())) throw new NoAuthorityException();
+        if(schedule.getScheduleType().equals(ScheduleType.INDIVIDUAL) && !authService.getLoginUser().equals(schedule.getMember())) throw new NoAuthorityException();
 
         schedule.updateSchedule(updateScheduleRequest.getTitle(), updateScheduleRequest.getStartDate(),
                 updateScheduleRequest.getEndDate(), updateScheduleRequest.getDDayOption(), updateScheduleRequest.getAlarmOptions());
@@ -62,10 +60,8 @@ public class ScheduleService implements EntityLoader<Schedule, UUID> {
         LocalDate firstDate = scheduleMapper.toFirstDate(month);
         LocalDate lastDate = firstDate.withDayOfMonth(firstDate.lengthOfMonth());
 
-        // 현재 로그인 중인 유저 받기
-        Member member = authService.getLoginUser();
         // 현재 유저 가족에 포함된 회원 정보 받기
-        Set<Member> familyMembers = member.getFamily().getMembers();
+        Set<Member> familyMembers = authService.getLoginUser().getFamily().getMembers();
 
         // 가족들의 일정 시작일 기준으로 정렬해서 받기
         List<Schedule> monthSchedules = familyMembers.stream()
@@ -78,10 +74,9 @@ public class ScheduleService implements EntityLoader<Schedule, UUID> {
     }
 
     public List<FindDDayByFamilyResponse> findDDayByFamily(){
-        // 현재 로그인 중인 유저 받기
-        Member member = authService.getLoginUser();
+
         // 현재 유저 가족에 포함된 회원 정보 받기
-        Set<Member> familyMembers = member.getFamily().getMembers();
+        Set<Member> familyMembers = authService.getLoginUser().getFamily().getMembers();
 
         // 가족들의 일정 중 dDay 옵션이 켜진 일정을 시작일 기준으로 정렬해서 받기
         List<Schedule> dDaySchedules = familyMembers.stream()

--- a/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
@@ -4,6 +4,7 @@ import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
 import com.owori.domain.schedule.dto.request.UpdateScheduleRequest;
+import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.entity.Schedule;
 import com.owori.domain.schedule.entity.ScheduleType;
@@ -66,6 +67,10 @@ public class ScheduleService implements EntityLoader<Schedule, UUID> {
                 .toList();
 
         return scheduleMapper.toResponseList(monthSchedule);
+    }
+
+    public List<FindDdayByFamilyResponse> findDdayByFamily(){
+        return null; // todo: 로직 작성
     }
 
     @Override

--- a/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
@@ -1,11 +1,10 @@
 package com.owori.domain.schedule.service;
 
-import com.owori.domain.family.entity.Family;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
 import com.owori.domain.schedule.dto.request.UpdateScheduleRequest;
-import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
+import com.owori.domain.schedule.dto.response.FindDDayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.entity.Schedule;
 import com.owori.domain.schedule.entity.ScheduleType;
@@ -78,7 +77,7 @@ public class ScheduleService implements EntityLoader<Schedule, UUID> {
         return scheduleMapper.toMonthResponseList(monthSchedules);
     }
 
-    public List<FindDdayByFamilyResponse> findDDayByFamily(){
+    public List<FindDDayByFamilyResponse> findDDayByFamily(){
         // 현재 로그인 중인 유저 받기
         Member member = authService.getLoginUser();
         // 현재 유저 가족에 포함된 회원 정보 받기

--- a/src/test/java/com/owori/domain/saying/service/SayingServiceTest.java
+++ b/src/test/java/com/owori/domain/saying/service/SayingServiceTest.java
@@ -111,7 +111,7 @@ public class SayingServiceTest extends LoginTest {
         // 서로에게 한마디 생성
         Saying saying1 = sayingRepository.save(new Saying("오늘 집 안 감", authService.getLoginUser(), List.of()));
         Saying saying2 = sayingRepository.save(new Saying("오늘 집 감", saveMember1, List.of()));
-        Saying saying3 = sayingRepository.save(new Saying("배고파", saveMember2, List.of()));
+        sayingRepository.save(new Saying("배고파", saveMember2, List.of()));
 
         // when
         entityManager.flush();

--- a/src/test/java/com/owori/domain/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/owori/domain/schedule/controller/ScheduleControllerTest.java
@@ -3,7 +3,7 @@ package com.owori.domain.schedule.controller;
 import com.owori.domain.member.entity.Color;
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
 import com.owori.domain.schedule.dto.request.UpdateScheduleRequest;
-import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
+import com.owori.domain.schedule.dto.response.FindDDayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.entity.Alarm;
 import com.owori.domain.schedule.entity.ScheduleType;
@@ -151,10 +151,10 @@ public class ScheduleControllerTest extends RestDocsTest {
     @DisplayName("GET / schedule 가족별 디데이 일정 조회 API 테스트")
     void findDDayByFamily() throws Exception {
         // given
-        List<FindDdayByFamilyResponse> expected = List.of(
-                new FindDdayByFamilyResponse(UUID.randomUUID(),"친구랑 여행", LocalDate.parse("2023-07-16"), LocalDate.parse("2023-07-09"),"D-DAY", ScheduleType.INDIVIDUAL, "벡스", Color.BLUE, true, List.of(Alarm.TODAY)),
-                new FindDdayByFamilyResponse(UUID.randomUUID(),"코딩 테스트", LocalDate.parse("2023-07-17"), LocalDate.parse("2023-07-15"), "D-1", ScheduleType.INDIVIDUAL , "오월이", Color.BLUE, true, List.of(Alarm.A_DAY_AGO)),
-                new FindDdayByFamilyResponse(UUID.randomUUID(),"가족여행",LocalDate.parse("2023-07-31"), LocalDate.parse("2023-08-02"),"D-15", ScheduleType.FAMILY, "벡스", Color.BLUE, true, List.of(Alarm.A_DAY_AGO, Alarm.A_WEEK_AGO))
+        List<FindDDayByFamilyResponse> expected = List.of(
+                new FindDDayByFamilyResponse(UUID.randomUUID(),"친구랑 여행", LocalDate.parse("2023-07-16"), LocalDate.parse("2023-07-09"),"D-DAY", ScheduleType.INDIVIDUAL, "벡스", Color.BLUE, true, List.of(Alarm.TODAY)),
+                new FindDDayByFamilyResponse(UUID.randomUUID(),"코딩 테스트", LocalDate.parse("2023-07-17"), LocalDate.parse("2023-07-15"), "D-1", ScheduleType.INDIVIDUAL , "오월이", Color.BLUE, true, List.of(Alarm.A_DAY_AGO)),
+                new FindDDayByFamilyResponse(UUID.randomUUID(),"가족여행",LocalDate.parse("2023-07-31"), LocalDate.parse("2023-08-02"),"D-15", ScheduleType.FAMILY, "벡스", Color.BLUE, true, List.of(Alarm.A_DAY_AGO, Alarm.A_WEEK_AGO))
         );
 
         given(scheduleService.findDDayByFamily()).willReturn(expected);

--- a/src/test/java/com/owori/domain/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/owori/domain/schedule/controller/ScheduleControllerTest.java
@@ -3,6 +3,7 @@ package com.owori.domain.schedule.controller;
 import com.owori.domain.member.entity.Color;
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
 import com.owori.domain.schedule.dto.request.UpdateScheduleRequest;
+import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.entity.Alarm;
 import com.owori.domain.schedule.entity.ScheduleType;
@@ -119,9 +120,9 @@ public class ScheduleControllerTest extends RestDocsTest {
     void findScheduleByMonth() throws Exception {
         // given
         List<FindScheduleByMonthResponse> expected = List.of(
-                new FindScheduleByMonthResponse(UUID.randomUUID(),"친구랑 여행", LocalDate.parse("2023-07-08"), LocalDate.parse("2023-07-09"), ScheduleType.INDIVIDUAL, UUID.randomUUID(), Color.BLUE, true, List.of(Alarm.TODAY)),
-                new FindScheduleByMonthResponse(UUID.randomUUID(),"코딩 테스트", LocalDate.parse("2023-07-15"), LocalDate.parse("2023-07-15"), ScheduleType.INDIVIDUAL , UUID.randomUUID(), Color.BLUE, true, List.of(Alarm.A_DAY_AGO)),
-                new FindScheduleByMonthResponse(UUID.randomUUID(),"가족여행",LocalDate.parse("2023-07-31"), LocalDate.parse("2023-08-02"), ScheduleType.FAMILY, UUID.randomUUID(), Color.BLUE, true, List.of(Alarm.A_DAY_AGO, Alarm.A_WEEK_AGO))
+                new FindScheduleByMonthResponse(UUID.randomUUID(),"친구랑 여행", LocalDate.parse("2023-07-08"), LocalDate.parse("2023-07-09"), ScheduleType.INDIVIDUAL, "벡스", Color.BLUE, true, List.of(Alarm.TODAY)),
+                new FindScheduleByMonthResponse(UUID.randomUUID(),"코딩 테스트", LocalDate.parse("2023-07-15"), LocalDate.parse("2023-07-15"), ScheduleType.INDIVIDUAL , "오월이", Color.BLUE, true, List.of(Alarm.A_DAY_AGO)),
+                new FindScheduleByMonthResponse(UUID.randomUUID(),"가족여행",LocalDate.parse("2023-07-31"), LocalDate.parse("2023-08-02"), ScheduleType.FAMILY, "가족", Color.BLUE, true, List.of(Alarm.A_DAY_AGO, Alarm.A_WEEK_AGO))
         );
 
         given(scheduleService.findScheduleByMonth(any())).willReturn(expected);
@@ -143,6 +144,37 @@ public class ScheduleControllerTest extends RestDocsTest {
 
         // docs
         perform.andDo(print())
-                .andDo(document("find schedule by month", getDocumentRequest(), getDocumentResponse()));
+                .andDo(document("find schedules by month", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("GET / schedule 가족별 디데이 일정 조회 API 테스트")
+    void findDDayByFamily() throws Exception {
+        // given
+        List<FindDdayByFamilyResponse> expected = List.of(
+                new FindDdayByFamilyResponse(UUID.randomUUID(),"친구랑 여행", LocalDate.parse("2023-07-16"), LocalDate.parse("2023-07-09"),"D-DAY", ScheduleType.INDIVIDUAL, "벡스", Color.BLUE, true, List.of(Alarm.TODAY)),
+                new FindDdayByFamilyResponse(UUID.randomUUID(),"코딩 테스트", LocalDate.parse("2023-07-17"), LocalDate.parse("2023-07-15"), "D-1", ScheduleType.INDIVIDUAL , "오월이", Color.BLUE, true, List.of(Alarm.A_DAY_AGO)),
+                new FindDdayByFamilyResponse(UUID.randomUUID(),"가족여행",LocalDate.parse("2023-07-31"), LocalDate.parse("2023-08-02"),"D-15", ScheduleType.FAMILY, "벡스", Color.BLUE, true, List.of(Alarm.A_DAY_AGO, Alarm.A_WEEK_AGO))
+        );
+
+        given(scheduleService.findDDayByFamily()).willReturn(expected);
+
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/schedule/dday")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString())
+                );
+
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").exists())
+                .andExpect(jsonPath("$[0].start_date").exists());
+
+        // docs
+        perform.andDo(print())
+                .andDo(document("find schedules by family", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/src/test/java/com/owori/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/owori/domain/schedule/service/ScheduleServiceTest.java
@@ -10,7 +10,7 @@ import com.owori.domain.member.entity.OAuth2Info;
 import com.owori.domain.member.service.AuthService;
 import com.owori.domain.schedule.dto.request.AddScheduleRequest;
 import com.owori.domain.schedule.dto.request.UpdateScheduleRequest;
-import com.owori.domain.schedule.dto.response.FindDdayByFamilyResponse;
+import com.owori.domain.schedule.dto.response.FindDDayByFamilyResponse;
 import com.owori.domain.schedule.dto.response.FindScheduleByMonthResponse;
 import com.owori.domain.schedule.entity.Schedule;
 import com.owori.domain.schedule.entity.ScheduleType;
@@ -76,6 +76,7 @@ public class ScheduleServiceTest extends LoginTest {
                                             assertThat(schedule.getStartDate()).isEqualTo(LocalDate.parse("2023-07-31"));
         });
     }
+
     @Test
     @DisplayName("일정 삭제가 수행되는가")
     void deleteSchedule() {
@@ -104,7 +105,7 @@ public class ScheduleServiceTest extends LoginTest {
         Member member1 = Member.builder().oAuth2Info(new OAuth2Info("123123", AuthProvider.APPLE)).build();
         Member member2 = Member.builder().oAuth2Info(new OAuth2Info("123126", AuthProvider.APPLE)).build();
         Member saveMember1 = memberRepository.save(member1);
-        Member saveMember2 = memberRepository.save(member2);
+        memberRepository.save(member2);
 
         // 가족에 멤버 추가
         Optional<Family> family = familyRepository.findByInviteCode(code);
@@ -115,10 +116,10 @@ public class ScheduleServiceTest extends LoginTest {
 
         // 일정 생성
         Schedule schedule5 = scheduleRepository.save(new Schedule("가족여행",LocalDate.parse("2023-07-31"), LocalDate.parse("2023-08-02"), ScheduleType.FAMILY, true, List.of(A_DAY_AGO, A_WEEK_AGO), authService.getLoginUser()));
-        Schedule schedule1 = scheduleRepository.save(new Schedule("코딩 테스트", LocalDate.parse("2023-06-22"), LocalDate.parse("2023-06-23"), ScheduleType.INDIVIDUAL, true, List.of(TODAY), authService.getLoginUser()));
-        Schedule schedule3 = scheduleRepository.save(new Schedule("친구랑 여행", LocalDate.parse("2023-07-08"), LocalDate.parse("2023-07-09"), ScheduleType.INDIVIDUAL,true, List.of(TODAY), member2));
+        scheduleRepository.save(new Schedule("코딩 테스트", LocalDate.parse("2023-06-22"), LocalDate.parse("2023-06-23"), ScheduleType.INDIVIDUAL, true, List.of(TODAY), authService.getLoginUser()));
+        scheduleRepository.save(new Schedule("친구랑 여행", LocalDate.parse("2023-07-08"), LocalDate.parse("2023-07-09"), ScheduleType.INDIVIDUAL,true, List.of(TODAY), member2));
         Schedule schedule4 = scheduleRepository.save(new Schedule("카카오 면접", LocalDate.parse("2023-07-11"), LocalDate.parse("2023-07-11"), ScheduleType.INDIVIDUAL,true, List.of(), member1));
-        Schedule schedule6 = scheduleRepository.save(new Schedule("친구랑 여행", LocalDate.parse("2023-08-01"), LocalDate.parse("2023-08-10"), ScheduleType.INDIVIDUAL,true, List.of(A_WEEK_AGO), authService.getLoginUser()));
+        scheduleRepository.save(new Schedule("친구랑 여행", LocalDate.parse("2023-08-01"), LocalDate.parse("2023-08-10"), ScheduleType.INDIVIDUAL,true, List.of(A_WEEK_AGO), authService.getLoginUser()));
         Schedule schedule2 = scheduleRepository.save(new Schedule("기말고사", LocalDate.parse("2023-06-22"), LocalDate.parse("2023-07-06"), ScheduleType.INDIVIDUAL,true, List.of(A_DAY_AGO), member1));
 
         // when
@@ -151,17 +152,17 @@ public class ScheduleServiceTest extends LoginTest {
 
         // 일정 생성
         Schedule schedule5 = scheduleRepository.save(new Schedule("가족여행",LocalDate.parse("2023-07-31"), LocalDate.parse("2023-08-02"), ScheduleType.FAMILY, true, List.of(A_DAY_AGO, A_WEEK_AGO), authService.getLoginUser()));
-        Schedule schedule1 = scheduleRepository.save(new Schedule("코딩 테스트", LocalDate.parse("2023-06-22"), LocalDate.parse("2023-06-23"), ScheduleType.INDIVIDUAL, true, List.of(TODAY), authService.getLoginUser()));
-        Schedule schedule3 = scheduleRepository.save(new Schedule("친구랑 여행", LocalDate.parse("2023-07-08"), LocalDate.parse("2023-07-09"), ScheduleType.INDIVIDUAL,true, List.of(TODAY), saveMember2));
-        Schedule schedule4 = scheduleRepository.save(new Schedule("카카오 면접", LocalDate.parse("2023-07-20"), LocalDate.parse("2023-07-24"), ScheduleType.INDIVIDUAL,false, List.of(), saveMember1));
+        scheduleRepository.save(new Schedule("코딩 테스트", LocalDate.parse("2023-06-22"), LocalDate.parse("2023-06-23"), ScheduleType.INDIVIDUAL, true, List.of(TODAY), authService.getLoginUser()));
+        scheduleRepository.save(new Schedule("친구랑 여행", LocalDate.parse("2023-07-08"), LocalDate.parse("2023-07-09"), ScheduleType.INDIVIDUAL,true, List.of(TODAY), saveMember2));
+        scheduleRepository.save(new Schedule("카카오 면접", LocalDate.parse("2023-07-20"), LocalDate.parse("2023-07-24"), ScheduleType.INDIVIDUAL,false, List.of(), saveMember1));
         Schedule schedule6 = scheduleRepository.save(new Schedule("친구랑 여행", LocalDate.parse("2023-08-01"), LocalDate.parse("2023-08-10"), ScheduleType.INDIVIDUAL,true, List.of(A_WEEK_AGO), authService.getLoginUser()));
-        Schedule schedule2 = scheduleRepository.save(new Schedule("기말고사", LocalDate.parse("2023-06-22"), LocalDate.parse("2023-07-06"), ScheduleType.INDIVIDUAL,true, List.of(A_DAY_AGO), saveMember1));
+        scheduleRepository.save(new Schedule("기말고사", LocalDate.parse("2023-06-22"), LocalDate.parse("2023-07-06"), ScheduleType.INDIVIDUAL,true, List.of(A_DAY_AGO), saveMember1));
 
         // when
-        List<FindDdayByFamilyResponse> responses = scheduleService.findDDayByFamily();
+        List<FindDDayByFamilyResponse> responses = scheduleService.findDDayByFamily();
 
         // then
-        assertThat(responses.stream().map(FindDdayByFamilyResponse::getId).toList()).isEqualTo(List.of(schedule5.getId(), schedule6.getId()));
+        assertThat(responses.stream().map(FindDDayByFamilyResponse::getId).toList()).isEqualTo(List.of(schedule5.getId(), schedule6.getId()));
     }
 
     @Test


### PR DESCRIPTION
## 추가/수정한 기능 설명
1.  디데이 조회 API 구현
  - 로그인 유저의 가족 일정 중 오늘 이후이고 디데이 옵션이 켜진 일정만 조회
  - 시작일을 기준으로 정렬
 
* DTO 수정 
  - 월별 조회 DTO에서 멤버 ID를 멤버 닉네임으로 변경

<br>

## 궁금한 사항
- 디데이를 직접 구해서 보내는게 나은지 아니면 시작일을 토대로 프론트에서 계산해서 하는 것이 나을지 고민입니다.
  -  프론트에서 계산하는게 시간적으로 차이가 덜 나지 않을까 싶기도해서 일단 둘다 보내줬습니다.


## check list
- [X] issue number를 브랜치 앞에 추가 했나요?
- [X] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [X] 추가/수정사항을 설명했나요?