### PR TITLE
[FIX] DTO 변수명 통일

### DIFF
--- a/src/main/java/com/owori/domain/member/dto/response/MemberHomeResponse.java
+++ b/src/main/java/com/owori/domain/member/dto/response/MemberHomeResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberHomeResponse {
-    private String familyName;
+    private String familyGroupName;
     private List<MemberProfileResponse> memberProfiles;
     private List<ScheduleDDayResponse> dDaySchedules;
     private List<String> familyImages;

--- a/src/main/java/com/owori/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/owori/domain/member/mapper/MemberMapper.java
@@ -36,7 +36,7 @@ public class MemberMapper {
     public MemberHomeResponse toHomeResponse(Member nowMember, List<ScheduleDDayResponse> dDayByFamilyResponses, List<SayingByFamilyResponse> sayingResponses) {
         Family family = nowMember.getFamily();
         return MemberHomeResponse.builder()
-                .familyName(family.getFamilyGroupName())
+                .familyGroupName(family.getFamilyGroupName())
                 .memberProfiles(toProfileResponseList(nowMember, family.getMembers()))
                 .dDaySchedules(dDayByFamilyResponses)
                 .familyImages(family.getImages())

--- a/src/main/java/com/owori/domain/saying/service/SayingService.java
+++ b/src/main/java/com/owori/domain/saying/service/SayingService.java
@@ -49,7 +49,7 @@ public class SayingService implements EntityLoader<Saying, UUID> {
         Saying saying = loadEntity(sayingId);
 
         // 서로에게 한마디 작성자와 현재 유저가 동일하지 않을 경우 예외처리
-        if(!authService.getLoginUser().equals(saying.getMember())) throw new NoAuthorityException();
+        if(!authService.getLoginUser().getId().equals(saying.getMember().getId())) throw new NoAuthorityException();
 
         // tagMemberIds 를 통해 tagMembers 구하기
         List<Member> tagMembers = memberService.findMembersByIds(request.getTagMembersId());
@@ -63,7 +63,7 @@ public class SayingService implements EntityLoader<Saying, UUID> {
     @Transactional
     public void deleteSaying(UUID sayingId) {
         Saying saying = loadEntity(sayingId);
-        if(!saying.getMember().equals(authService.getLoginUser())) throw new NoAuthorityException();
+        if(!saying.getMember().getId().equals(authService.getLoginUser().getId())) throw new NoAuthorityException();
         saying.changeModifiable();
     }
 

--- a/src/main/java/com/owori/domain/schedule/dto/request/AddScheduleRequest.java
+++ b/src/main/java/com/owori/domain/schedule/dto/request/AddScheduleRequest.java
@@ -17,7 +17,7 @@ public class AddScheduleRequest {
     private LocalDate startDate;
     private LocalDate endDate;
     private ScheduleType scheduleType;
-    private Boolean dDayOption;
+    private Boolean ddayOption;
     private List<Alarm> alarmOptions;
 
 }

--- a/src/main/java/com/owori/domain/schedule/dto/request/UpdateScheduleRequest.java
+++ b/src/main/java/com/owori/domain/schedule/dto/request/UpdateScheduleRequest.java
@@ -15,7 +15,7 @@ public class UpdateScheduleRequest {
     private String title;
     private LocalDate startDate;
     private LocalDate endDate;
-    private Boolean dDayOption;
+    private Boolean ddayOption;
     private List<Alarm> alarmOptions;
 }
 

--- a/src/main/java/com/owori/domain/schedule/dto/response/ScheduleByMonthResponse.java
+++ b/src/main/java/com/owori/domain/schedule/dto/response/ScheduleByMonthResponse.java
@@ -24,6 +24,6 @@ public class ScheduleByMonthResponse {
     private ScheduleType scheduleType;
     private String memberNickname;
     private Color color;
-    private Boolean dDayOption;
+    private Boolean ddayOption;
     private List<Alarm> alarmOptions;
 }

--- a/src/main/java/com/owori/domain/schedule/dto/response/ScheduleDDayResponse.java
+++ b/src/main/java/com/owori/domain/schedule/dto/response/ScheduleDDayResponse.java
@@ -25,7 +25,7 @@ public class ScheduleDDayResponse {
     private ScheduleType scheduleType;
     private String memberNickname;
     private Color color;
-    private Boolean dDayOption;
+    private Boolean ddayOption;
     private List<Alarm> alarmOptions;
 
 }

--- a/src/main/java/com/owori/domain/schedule/entity/Alarm.java
+++ b/src/main/java/com/owori/domain/schedule/entity/Alarm.java
@@ -2,16 +2,14 @@ package com.owori.domain.schedule.entity;
 
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum Alarm {
     TODAY("당일"),
     A_DAY_AGO("전날"),
     A_WEEK_AGO("일주일전");
 
     private final String toKorean;
-
-    Alarm(String alarmType) {
-        this.toKorean = alarmType;
-    }
 }

--- a/src/main/java/com/owori/domain/schedule/entity/ScheduleType.java
+++ b/src/main/java/com/owori/domain/schedule/entity/ScheduleType.java
@@ -2,8 +2,10 @@ package com.owori.domain.schedule.entity;
 
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum ScheduleType {
 
     FAMILY("가족"),
@@ -11,7 +13,4 @@ public enum ScheduleType {
 
     private final String toKorean;
 
-    ScheduleType(String scheduleType) {
-        this.toKorean = scheduleType;
-    }
 }

--- a/src/main/java/com/owori/domain/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/owori/domain/schedule/mapper/ScheduleMapper.java
@@ -19,7 +19,7 @@ public class ScheduleMapper {
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
                 .scheduleType(request.getScheduleType())
-                .dDayOption(request.getDDayOption())
+                .dDayOption(request.getDdayOption())
                 .alarmList(request.getAlarmOptions())
                 .member(member)
                 .build();
@@ -46,7 +46,7 @@ public class ScheduleMapper {
                 .scheduleType(schedule.getScheduleType())
                 .memberNickname( schedule.getMember().getNickname())
                 .color(schedule.getMember().getColor())
-                .dDayOption(schedule.getDDayOption())
+                .ddayOption(schedule.getDDayOption())
                 .alarmOptions(schedule.getAlarmList())
                 .build();
     }
@@ -61,7 +61,7 @@ public class ScheduleMapper {
                 .scheduleType(schedule.getScheduleType())
                 .memberNickname(schedule.getMember().getNickname())
                 .color(schedule.getMember().getColor())
-                .dDayOption(schedule.getDDayOption())
+                .ddayOption(schedule.getDDayOption())
                 .alarmOptions(schedule.getAlarmList())
                 .build();
     }

--- a/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/owori/domain/schedule/service/ScheduleService.java
@@ -39,10 +39,10 @@ public class ScheduleService implements EntityLoader<Schedule, UUID> {
         // id 값으로 일정 찾기
         Schedule schedule = loadEntity(scheduleId);
         // 현재 일정이 개인 일정이고 현재 사용자와 생성자가 다를 경우 예외처리
-        if(schedule.getScheduleType().equals(ScheduleType.INDIVIDUAL) && !authService.getLoginUser().equals(schedule.getMember())) throw new NoAuthorityException();
+        if(schedule.getScheduleType().equals(ScheduleType.INDIVIDUAL) && !authService.getLoginUser().getId().equals(schedule.getMember().getId())) throw new NoAuthorityException();
 
         schedule.updateSchedule(updateScheduleRequest.getTitle(), updateScheduleRequest.getStartDate(),
-                updateScheduleRequest.getEndDate(), updateScheduleRequest.getDDayOption(), updateScheduleRequest.getAlarmOptions());
+                updateScheduleRequest.getEndDate(), updateScheduleRequest.getDdayOption(), updateScheduleRequest.getAlarmOptions());
 
         return new IdResponse<>(scheduleId);
     }
@@ -51,7 +51,7 @@ public class ScheduleService implements EntityLoader<Schedule, UUID> {
     public void deleteSchedule(UUID scheduleId) {
         Schedule schedule = loadEntity(scheduleId);
         // 생성자와 동일하지 않을 경우 예외처리
-        if(!schedule.getMember().equals(authService.getLoginUser())) throw new NoAuthorityException();
+        if(!authService.getLoginUser().getId().equals(schedule.getMember().getId())) throw new NoAuthorityException();
         schedule.delete();
     }
 

--- a/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
@@ -230,7 +230,7 @@ class MemberControllerTest extends RestDocsTest {
 
         // then
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.family_name").exists());
+                .andExpect(jsonPath("$.family_group_name").exists());
 
         // docs
         perform.andDo(print())

--- a/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
@@ -176,7 +176,7 @@ class MemberServiceTest extends LoginTest {
         // when
         MemberHomeResponse responses = memberService.findHomeData();
 
-        assertThat(familyName).isEqualTo(responses.getFamilyName());
+        assertThat(familyName).isEqualTo(responses.getFamilyGroupName());
         assertThat(responses.getMemberProfiles().stream().map(MemberProfileResponse::getId).toList()).isEqualTo(List.of(authService.getLoginUser().getId(), saveMember1.getId()));
         assertThat(responses.getFamilySayings().stream().map(SayingByFamilyResponse::getId)).hasSameElementsAs(List.of(saying1.getId(), saying2.getId()));
     }


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. DTO 변수명 양식 통일(수정사항 없음)
2. schedule관련 dto 내 필드명 변경
  - dDayOption -> ddayOption
3. schedule 및 saying 수정, 삭제 권한 구문 수정
  - member끼리 비교 시 항상 같지 않게 됨
  - memberId로 비교하도록 수정
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?