### PR TITLE
[FEAT] 최근 검색어 API, API Docs

### DIFF
--- a/src/main/java/com/owori/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/owori/domain/keyword/controller/KeywordController.java
@@ -1,0 +1,46 @@
+package com.owori.domain.keyword.controller;
+
+import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.service.KeywordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/keywords")
+public class KeywordController {
+    private final KeywordService keywordService;
+
+    /**
+     * 최근 검색어를 조회 컨트롤러입니다.
+     * @return 검색어 정보가 담긴 dto list를 반환합니다.
+     */
+    @GetMapping
+    public ResponseEntity<List<FindKeywordsResponse>> findSearchWords(){
+        return ResponseEntity.ok(keywordService.findSearchWords());
+    }
+
+
+    /**
+     * 최근 검색어를 전체 삭제하는 컨트롤러입니다.
+     */
+    @DeleteMapping
+    public ResponseEntity<Void> deleteSearchWords(){
+        keywordService.deleteSearchWords();
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 최근 검색어를 단일 삭제하는 컨트롤러입니다.
+     * @param keywordId 삭제할 검색어의 id 값
+     */
+    @DeleteMapping("/{keywordId}")
+    public ResponseEntity<Void> deleteSearchWords(@PathVariable UUID keywordId){
+        keywordService.deleteSearchWord(keywordId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/owori/domain/keyword/entity/Keyword.java
+++ b/src/main/java/com/owori/domain/keyword/entity/Keyword.java
@@ -1,0 +1,43 @@
+package com.owori.domain.keyword.entity;
+
+import com.owori.domain.member.entity.*;
+import com.owori.global.audit.AuditListener;
+import com.owori.global.audit.Auditable;
+import com.owori.global.audit.BaseTime;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Where(clause = "deleted_at is null")
+@EntityListeners(AuditListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Keyword implements Auditable {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    private String contents;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Member member;
+
+    @Setter
+    @Embedded
+    @Column(nullable = false)
+    private BaseTime baseTime;
+
+    @Builder
+    public Keyword(String contents, Member member) {
+        this.contents = contents;
+        this.member = member;
+    }
+
+}

--- a/src/main/java/com/owori/domain/keyword/entity/dto/response/FindKeywordsResponse.java
+++ b/src/main/java/com/owori/domain/keyword/entity/dto/response/FindKeywordsResponse.java
@@ -1,0 +1,13 @@
+package com.owori.domain.keyword.entity.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class FindKeywordsResponse {
+    private UUID keywordId;
+    private String contents;
+}

--- a/src/main/java/com/owori/domain/keyword/repository/JpaKeywordRepository.java
+++ b/src/main/java/com/owori/domain/keyword/repository/JpaKeywordRepository.java
@@ -1,0 +1,9 @@
+package com.owori.domain.keyword.repository;
+
+import com.owori.domain.keyword.entity.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaKeywordRepository extends JpaRepository<Keyword, UUID>, KeywordRepository {
+}

--- a/src/main/java/com/owori/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/owori/domain/keyword/repository/KeywordRepository.java
@@ -1,0 +1,17 @@
+package com.owori.domain.keyword.repository;
+
+import com.owori.domain.keyword.entity.Keyword;
+import com.owori.domain.member.entity.Member;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface KeywordRepository {
+    Optional<Keyword> findByContents(String contents);
+    List<Keyword> findByMember(Member member);
+    Keyword save(Keyword keyword);
+    void deleteAll();
+    void delete(Keyword keyword);
+    Optional<Keyword> findById(UUID id);
+}

--- a/src/main/java/com/owori/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/owori/domain/keyword/service/KeywordService.java
@@ -1,0 +1,56 @@
+package com.owori.domain.keyword.service;
+
+import com.owori.domain.keyword.entity.Keyword;
+import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.repository.KeywordRepository;
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.service.AuthService;
+import com.owori.global.exception.EntityNotFoundException;
+import com.owori.global.service.EntityLoader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordService implements EntityLoader<Keyword, UUID> {
+
+    private final KeywordRepository keywordRepository;
+    private final AuthService authService;
+
+    public void addKeyword(String keyword, Member member) {
+        Optional<Keyword> findKeyword = keywordRepository.findByContents(keyword);
+        findKeyword.ifPresent(word -> word.getBaseTime().setCreatedAt(LocalDateTime.now())); // 같은 검색어가 이미 존재하면 createdAt만 update
+        findKeyword.orElseGet(() -> keywordRepository.save(new Keyword(keyword, member)));
+    }
+
+    public List<FindKeywordsResponse> findSearchWords() {
+        Member loginUser = authService.getLoginUser();
+        List<Keyword> keywordList = keywordRepository.findByMember(loginUser);
+
+        return Optional.ofNullable(keywordList)
+                .map(
+                        keywords -> keywords.stream()
+                                .map( keyword -> new FindKeywordsResponse(keyword.getId(), keyword.getContents())).toList())
+                .orElse(null);
+    }
+
+    public void deleteSearchWords() {
+        keywordRepository.deleteAll();
+    }
+
+    public void deleteSearchWord(UUID keywordId) {
+        Keyword keyword = loadEntity(keywordId);
+        keywordRepository.delete(keyword);
+    }
+
+    @Override
+    public Keyword loadEntity(UUID id) {
+        return keywordRepository.findById(id).orElseThrow(() -> new EntityNotFoundException());
+    }
+
+}

--- a/src/main/java/com/owori/domain/story/service/StoryService.java
+++ b/src/main/java/com/owori/domain/story/service/StoryService.java
@@ -3,6 +3,7 @@ package com.owori.domain.story.service;
 import com.owori.domain.comment.dto.response.CommentResponse;
 import com.owori.domain.family.entity.Family;
 import com.owori.domain.image.service.ImageService;
+import com.owori.domain.keyword.service.KeywordService;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
 import com.owori.domain.story.dto.request.PostStoryRequest;
@@ -31,6 +32,7 @@ public class StoryService implements EntityLoader<Story, UUID> {
     private final StoryMapper storyMapper;
     private final ImageService imageService;
     private final AuthService authService;
+    private final KeywordService keywordService;
 
     public IdResponse<UUID> addStory(PostStoryRequest request) {
         Member loginUser = authService.getLoginUser();
@@ -84,8 +86,9 @@ public class StoryService implements EntityLoader<Story, UUID> {
     }
 
     public FindAllStoryGroupResponse findStoryBySearch(String keyword, Pageable pageable, LocalDate lastViewed) {
-        Family family = authService.getLoginUser().getFamily();
-        Slice<Story> storyBySearch = storyRepository.findStoryBySearch(pageable, keyword, family, lastViewed);
+        Member loginUser = authService.getLoginUser();
+        Slice<Story> storyBySearch = storyRepository.findStoryBySearch(pageable, keyword, loginUser.getFamily(), lastViewed);
+        keywordService.addKeyword(keyword, loginUser);
 
         return storyMapper.toFindAllStoryGroupDto(storyBySearch);
     }

--- a/src/test/java/com/owori/domain/keyword/controller/KeywordControllerTest.java
+++ b/src/test/java/com/owori/domain/keyword/controller/KeywordControllerTest.java
@@ -1,0 +1,105 @@
+package com.owori.domain.keyword.controller;
+
+import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.service.KeywordService;
+import com.owori.support.docs.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.owori.support.docs.ApiDocsUtils.getDocumentRequest;
+import static com.owori.support.docs.ApiDocsUtils.getDocumentResponse;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Keyword 컨트롤러의")
+@WebMvcTest(KeywordController.class)
+public class KeywordControllerTest extends RestDocsTest {
+
+    @MockBean private KeywordService keywordService;
+
+    @Test
+    @DisplayName("GET /keywords 최근 검색어 조회 API 테스트")
+    void findAllKeyword() throws Exception {
+        //given
+        List<FindKeywordsResponse> expected = List.of(new FindKeywordsResponse(UUID.randomUUID(), "강화도"),
+                new FindKeywordsResponse(UUID.randomUUID(), "간장 게장"),
+                new FindKeywordsResponse(UUID.randomUUID(), "야구장")
+        );
+        given(keywordService.findSearchWords()).willReturn(expected);
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/keywords")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString())
+                );
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("find keywords", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("DELETE /keywords 최근 검색어 전체 삭제 API 테스트")
+    void deleteAllKeyword() throws Exception {
+        //given
+        doNothing().when(keywordService).deleteSearchWords();
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/keywords")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString())
+                );
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("delete keywords", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("DELETE /keywords 최근 검색어 전체 삭제 API 테스트")
+    void deleteKeywordById() throws Exception {
+        //given
+        doNothing().when(keywordService).deleteSearchWords();
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/keywords/{keywordId}", UUID.randomUUID())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString())
+                );
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("delete keyword", getDocumentRequest(), getDocumentResponse()));
+    }
+
+}

--- a/src/test/java/com/owori/domain/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/com/owori/domain/keyword/service/KeywordServiceTest.java
@@ -1,0 +1,134 @@
+package com.owori.domain.keyword.service;
+
+import com.owori.domain.family.entity.Family;
+import com.owori.domain.family.repository.FamilyRepository;
+import com.owori.domain.keyword.entity.Keyword;
+import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.repository.KeywordRepository;
+import com.owori.domain.member.entity.Member;
+import com.owori.domain.member.service.AuthService;
+import com.owori.domain.story.entity.Story;
+import com.owori.domain.story.repository.StoryRepository;
+import com.owori.domain.story.service.StoryService;
+import com.owori.global.exception.EntityNotFoundException;
+import com.owori.support.database.DatabaseTest;
+import com.owori.support.database.LoginTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DatabaseTest
+@DisplayName("Keyword 서비스의")
+public class KeywordServiceTest extends LoginTest {
+
+    @Autowired private KeywordService keywordService;
+    @Autowired private KeywordRepository keywordRepository;
+    @Autowired private AuthService authService;
+    @Autowired private StoryRepository storyRepository;
+    @Autowired private FamilyRepository familyRepository;
+    @Autowired private StoryService storyService;
+    @Autowired private EntityManager em;
+
+
+
+    @Test
+    @DisplayName("검색어가 저장되는가")
+    void addStorySearchWord() {
+        //given
+        Member member = authService.getLoginUser();
+        Family family = new Family("우리집", member, "code");
+        Story story = new Story("기다리고 기다리던 하루", "내용", LocalDate.parse("2017-12-25"), LocalDate.parse("2017-12-30"), member);
+
+        familyRepository.save(family);
+        storyRepository.save(story);
+
+        //when
+        storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("createdAt")), null);
+        storyService.findStoryBySearch("우리집", PageRequest.of(0, 4, Sort.by("createdAt")), null);
+        storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("createdAt")), null);
+
+        List<Keyword> keywords = keywordRepository.findByMember(member);
+
+        //then
+        assertThat(keywords.get(0).getMember()).isEqualTo(member);
+        assertThat(keywords.size()).isEqualTo(2);
+        assertThat(keywords.get(0).getContents()).isEqualTo("기다리");
+        assertThat(keywords.get(1).getContents()).isEqualTo("우리집");
+    }
+
+    @Test
+    @DisplayName("검색어 조회가 되는가")
+    void findAllStorySearchWord() {
+        //given
+        Member member = authService.getLoginUser();
+        Family family = new Family("우리집", member, "code");
+        Story story = new Story("기다리고 기다리던 하루", "내용", LocalDate.parse("2017-12-25"), LocalDate.parse("2017-12-30"), member);
+
+        familyRepository.save(family);
+        storyRepository.save(story);
+
+        //when
+        storyService.findStoryBySearch("야호", PageRequest.of(0, 4, Sort.by("createdAt")), null);
+        storyService.findStoryBySearch("우리집", PageRequest.of(0, 4, Sort.by("createdAt")), null);
+        storyService.findStoryBySearch("야호", PageRequest.of(0, 4, Sort.by("createdAt")), null);
+
+        List<FindKeywordsResponse> searchWords = keywordService.findSearchWords();
+
+        //then
+        assertThat(searchWords.size()).isEqualTo(2);
+        assertThat(searchWords.get(0).getContents()).isEqualTo("야호");
+        assertThat(searchWords.get(1).getContents()).isEqualTo("우리집");
+    }
+
+    @Test
+    @DisplayName("검색어 단일 삭제가 실행되는가")
+    void removeStorySearchWord() {
+        //given
+        Member member = authService.getLoginUser();
+        Keyword keyword = new Keyword("검색어 삭제 테스트", member);
+        keywordRepository.save(keyword);
+
+        //when
+        keywordService.deleteSearchWord(keyword.getId());
+        em.flush();
+        em.clear();
+
+        //then
+        assertThrows(EntityNotFoundException.class, () -> keywordService.loadEntity(keyword.getId()));
+
+    }
+
+    @Test
+    @DisplayName("검색어 전체 삭제가 실행되는가")
+    void removeAllStorySearchWord() {
+        //given
+        Member member = authService.getLoginUser();
+        Keyword keyword = new Keyword("검색어", member);
+        Keyword keyword1 = new Keyword("전체", member);
+        Keyword keyword2 = new Keyword("삭제 테스트", member);
+        keywordRepository.save(keyword);
+        keywordRepository.save(keyword1);
+        keywordRepository.save(keyword2);
+
+        //when
+        keywordService.deleteSearchWords();
+        em.flush();
+        em.clear();
+
+        //then
+        assertThrows(EntityNotFoundException.class, () -> keywordService.loadEntity(keyword.getId()));
+        assertThrows(EntityNotFoundException.class, () -> keywordService.loadEntity(keyword1.getId()));
+        assertThrows(EntityNotFoundException.class, () -> keywordService.loadEntity(keyword2.getId()));
+
+    }
+}

--- a/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
+++ b/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
@@ -15,7 +15,6 @@ import com.owori.domain.story.dto.request.PostStoryRequest;
 import com.owori.domain.story.dto.response.FindAllStoryGroupResponse;
 import com.owori.domain.story.dto.response.FindStoryResponse;
 import com.owori.domain.story.entity.Story;
-import com.owori.domain.comment.entity.TimesAgo;
 import com.owori.domain.story.repository.StoryRepository;
 import com.owori.global.dto.IdResponse;
 import com.owori.global.exception.EntityNotFoundException;
@@ -29,7 +28,6 @@ import org.springframework.data.domain.Sort;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## 이슈 번호 
Closes #58 

## 추가/수정한 기능 설명
- 이야기 검색 시 검색어가 저장되도록 코드 추가했습니다.
- 최근 검색어 전체 조회 / 단일 삭제 / 전체 삭제 api 구현했습니다.
<br>

## 리뷰 포인트
검색어 삭제 시 데이터 베이스에서 hard delete 해도 큰 문제가 없을 것 같아 hard delete 되도록 구현했습니다.
<br>

## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?