### PR TITLE
[CHORE] Lob 추가로 refresh token 데이터 타입 변경

### DIFF
--- a/src/main/java/com/owori/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/com/owori/config/querydsl/QueryDslConfig.java
@@ -1,4 +1,4 @@
-package com.owori.config.security.querydsl;
+package com.owori.config.querydsl;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/owori/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/owori/config/security/jwt/JwtTokenProvider.java
@@ -18,8 +18,8 @@ public class JwtTokenProvider {
     private static final Long ACCESS_TOKEN_EXPIRE_LENGTH = 60L * 60 * 24 * 1000; // 1 Day
     private static final Long REFRESH_TOKEN_EXPIRE_LENGTH = 60L * 60 * 24 * 14 * 1000; // 14 Days
 
-    public JwtToken createToken(Member loginUser, String clientId) {
-        Claims claims = getClaims(loginUser, clientId);
+    public JwtToken createToken(Member loginUser) {
+        Claims claims = getClaims(loginUser);
 
         String accessToken = getToken(loginUser, claims, ACCESS_TOKEN_EXPIRE_LENGTH);
         String refreshToken = getToken(loginUser, claims, REFRESH_TOKEN_EXPIRE_LENGTH);
@@ -46,10 +46,9 @@ public class JwtTokenProvider {
         memberRepository.updateRefreshToken(id, refreshToken);
     }
 
-    private Claims getClaims(Member loginUser, String token) {
+    private Claims getClaims(Member loginUser) {
         Claims claims = Jwts.claims();
         claims.put("id", loginUser.getId().toString());
-        claims.put("clientId", token);
         return claims;
     }
 

--- a/src/main/java/com/owori/domain/member/entity/OAuth2Info.java
+++ b/src/main/java/com/owori/domain/member/entity/OAuth2Info.java
@@ -5,10 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import javax.persistence.*;
 import java.util.Objects;
 
 @Getter
@@ -16,6 +13,7 @@ import java.util.Objects;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OAuth2Info {
+    @Lob
     @Column(nullable = false)
     private String clientId;
 

--- a/src/main/java/com/owori/domain/member/service/AuthService.java
+++ b/src/main/java/com/owori/domain/member/service/AuthService.java
@@ -28,11 +28,11 @@ public class AuthService {
 
         validateSavedRefreshTokenIfExpired(oldRefreshToken, user.getId());
 
-        return createAndUpdateToken(user, user.getOAuth2Info().getClientId());
+        return createAndUpdateToken(user);
     }
 
-    public JwtToken createAndUpdateToken(final Member user, final String clientId) {
-        JwtToken jwtToken = jwtTokenProvider.createToken(user, clientId);
+    public JwtToken createAndUpdateToken(final Member user) {
+        JwtToken jwtToken = jwtTokenProvider.createToken(user);
 
         memberRepository.updateRefreshToken(user.getId(), jwtToken.getRefreshToken());
         return jwtToken;

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -53,7 +53,7 @@ public class MemberService implements EntityLoader<Member, UUID> {
         Member member = memberRepository.findByClientIdAndAuthProvider(clientId, memberRequest.getAuthProvider())
                 .orElseGet(() -> memberRepository.save(memberMapper.toEntity(clientId, memberRequest)));
 
-        JwtToken jwtToken = createMemberJwtToken(member, member.getOAuth2Info().getClientId());
+        JwtToken jwtToken = createMemberJwtToken(member);
         return memberMapper.toJwtResponse(jwtToken, member.getId());
     }
 
@@ -64,8 +64,8 @@ public class MemberService implements EntityLoader<Member, UUID> {
         return memberRequest.getToken();
     }
 
-    private JwtToken createMemberJwtToken(final Member member, final String token) {
-        return authService.createAndUpdateToken(member, token);
+    private JwtToken createMemberJwtToken(final Member member) {
+        return authService.createAndUpdateToken(member);
     }
 
     private KakaoMemberResponse requestToKakao(final String token) {


### PR DESCRIPTION
## 추가/수정한 기능 설명
- refresh token 의 길이를 고려해 Lob 어노테이션 추가
- querydsl config 패키지 경로 변경
- Jwt 토큰 생성시 클라이언트에서 받은 토큰 사용하지 않도록 수정

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?