### PR TITLE
[FEAT] 마이페이지 유저 프로필 조회 API, API Docs

### DIFF
--- a/src/docs/member.adoc
+++ b/src/docs/member.adoc
@@ -25,3 +25,6 @@ operation::update member emotional badge[snippets='http-request,http-response']
 
 === 멤버 홈화면 조회
 operation::find home data[snippets='http-request,http-response']
+
+=== 마이페이지 유저 프로필 조회
+operation::get mypage profile[snippets='http-request,http-response']

--- a/src/main/java/com/owori/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/com/owori/domain/keyword/controller/KeywordController.java
@@ -1,6 +1,6 @@
 package com.owori.domain.keyword.controller;
 
-import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.dto.response.FindKeywordsResponse;
 import com.owori.domain.keyword.service.KeywordService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/owori/domain/keyword/dto/response/FindKeywordsResponse.java
+++ b/src/main/java/com/owori/domain/keyword/dto/response/FindKeywordsResponse.java
@@ -1,4 +1,4 @@
-package com.owori.domain.keyword.entity.dto.response;
+package com.owori.domain.keyword.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/owori/domain/keyword/service/KeywordService.java
+++ b/src/main/java/com/owori/domain/keyword/service/KeywordService.java
@@ -1,7 +1,7 @@
 package com.owori.domain.keyword.service;
 
 import com.owori.domain.keyword.entity.Keyword;
-import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.dto.response.FindKeywordsResponse;
 import com.owori.domain.keyword.repository.KeywordRepository;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;

--- a/src/main/java/com/owori/domain/member/controller/MemberController.java
+++ b/src/main/java/com/owori/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.owori.domain.member.dto.request.MemberDetailsRequest;
 import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.response.MemberJwtResponse;
+import com.owori.domain.member.dto.response.MyPageProfileResponse;
 import com.owori.domain.member.service.MemberService;
 import com.owori.global.dto.ImageResponse;
 import lombok.RequiredArgsConstructor;
@@ -100,5 +101,14 @@ public class MemberController {
     @GetMapping("/home")
     public ResponseEntity<MemberHomeResponse> findHomeData() {
         return ResponseEntity.ok(memberService.findHomeData());
+    }
+
+    /**
+     * 마이페이지 유저 조회 컨트롤러입니다.
+     * @return 로그인 유저 정보를 반환합니다.
+     */
+    @GetMapping("/profile")
+    public ResponseEntity<MyPageProfileResponse> getMyPageProfile() {
+        return ResponseEntity.ok(memberService.getMyPageProfile());
     }
 }

--- a/src/main/java/com/owori/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/owori/domain/member/dto/response/MemberProfileResponse.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class MemberProfileResponse {
     private UUID id;
-    private String nickName;
+    private String nickname;
     private String profileImage;
     private EmotionalBadge emotionalBadge;
 }

--- a/src/main/java/com/owori/domain/member/dto/response/MyPageProfileResponse.java
+++ b/src/main/java/com/owori/domain/member/dto/response/MyPageProfileResponse.java
@@ -1,5 +1,6 @@
 package com.owori.domain.member.dto.response;
 
+import com.owori.domain.member.entity.Color;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +13,5 @@ import java.time.LocalDate;
 public class MyPageProfileResponse {
     private String nickname;
     private LocalDate birthday;
-    private String color;
+    private Color color;
 }

--- a/src/main/java/com/owori/domain/member/dto/response/MyPageProfileResponse.java
+++ b/src/main/java/com/owori/domain/member/dto/response/MyPageProfileResponse.java
@@ -12,5 +12,5 @@ import java.time.LocalDate;
 public class MyPageProfileResponse {
     private String nickname;
     private LocalDate birthday;
-    private String myColor;
+    private String color;
 }

--- a/src/main/java/com/owori/domain/member/dto/response/MyPageProfileResponse.java
+++ b/src/main/java/com/owori/domain/member/dto/response/MyPageProfileResponse.java
@@ -1,0 +1,16 @@
+package com.owori.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyPageProfileResponse {
+    private String nickname;
+    private LocalDate birthday;
+    private String myColor;
+}

--- a/src/main/java/com/owori/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/owori/domain/member/mapper/MemberMapper.java
@@ -58,7 +58,7 @@ public class MemberMapper {
     private MemberProfileResponse toProfileResponse(Member member) {
         return MemberProfileResponse.builder()
                 .id(member.getId())
-                .nickName(member.getNickname())
+                .nickname(member.getNickname())
                 .profileImage(member.getProfileImage())
                 .emotionalBadge(member.getEmotionalBadge())
                 .build();

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -136,7 +136,7 @@ public class MemberService implements EntityLoader<Member, UUID> {
 
     public MyPageProfileResponse getMyPageProfile() {
         Member loginUser = authService.getLoginUser();
-        return new MyPageProfileResponse(loginUser.getNickname(), loginUser.getBirthDay(), loginUser.getColor().name());
+        return new MyPageProfileResponse(loginUser.getNickname(), loginUser.getBirthDay(), loginUser.getColor());
     }
 
 

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -136,7 +136,7 @@ public class MemberService implements EntityLoader<Member, UUID> {
 
     public MyPageProfileResponse getMyPageProfile() {
         Member loginUser = authService.getLoginUser();
-        return new MyPageProfileResponse(loginUser.getNickname(), loginUser.getBirthDay(), loginUser.getColor().name().toLowerCase());
+        return new MyPageProfileResponse(loginUser.getNickname(), loginUser.getBirthDay(), loginUser.getColor().name());
     }
 
 

--- a/src/main/java/com/owori/domain/member/service/MemberService.java
+++ b/src/main/java/com/owori/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.response.MemberHomeResponse;
 import com.owori.domain.member.dto.response.MemberJwtResponse;
+import com.owori.domain.member.dto.response.MyPageProfileResponse;
 import com.owori.domain.member.entity.AuthProvider;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.exception.NoSuchProfileImageException;
@@ -127,5 +128,10 @@ public class MemberService implements EntityLoader<Member, UUID> {
         List<SayingByFamilyResponse> sayingResponses = nowMember.getFamily().getMembers().stream()
                 .map(Member::getSaying).filter(Objects::nonNull).map(sayingMapper::toResponse).toList();
         return memberMapper.toHomeResponse(nowMember, dDayByFamilyResponses, sayingResponses);
+    }
+
+    public MyPageProfileResponse getMyPageProfile() {
+        Member loginUser = authService.getLoginUser();
+        return new MyPageProfileResponse(loginUser.getNickname(), loginUser.getBirthDay(), loginUser.getColor().name().toLowerCase());
     }
 }

--- a/src/test/java/com/owori/domain/keyword/controller/KeywordControllerTest.java
+++ b/src/test/java/com/owori/domain/keyword/controller/KeywordControllerTest.java
@@ -1,6 +1,6 @@
 package com.owori.domain.keyword.controller;
 
-import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.dto.response.FindKeywordsResponse;
 import com.owori.domain.keyword.service.KeywordService;
 import com.owori.support.docs.RestDocsTest;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/owori/domain/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/com/owori/domain/keyword/service/KeywordServiceTest.java
@@ -3,7 +3,7 @@ package com.owori.domain.keyword.service;
 import com.owori.domain.family.entity.Family;
 import com.owori.domain.family.repository.FamilyRepository;
 import com.owori.domain.keyword.entity.Keyword;
-import com.owori.domain.keyword.entity.dto.response.FindKeywordsResponse;
+import com.owori.domain.keyword.dto.response.FindKeywordsResponse;
 import com.owori.domain.keyword.repository.KeywordRepository;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
@@ -23,7 +23,6 @@ import javax.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
@@ -266,7 +266,7 @@ class MemberControllerTest extends RestDocsTest {
     @DisplayName("마이페이지 유저 조회가 제대로 수행되는가")
     void findMyPageProfile() throws Exception {
         //given
-        MyPageProfileResponse expected = new MyPageProfileResponse("꼼지락", LocalDate.of(2000, 04, 22), "red");
+        MyPageProfileResponse expected = new MyPageProfileResponse("꼼지락", LocalDate.of(2000, 04, 22), "RED");
         given(memberService.getMyPageProfile()).willReturn(expected);
 
         //when

--- a/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
@@ -266,7 +266,7 @@ class MemberControllerTest extends RestDocsTest {
     @DisplayName("마이페이지 유저 조회가 제대로 수행되는가")
     void findMyPageProfile() throws Exception {
         //given
-        MyPageProfileResponse expected = new MyPageProfileResponse("꼼지락", LocalDate.of(2000, 04, 22), "RED");
+        MyPageProfileResponse expected = new MyPageProfileResponse("꼼지락", LocalDate.of(2000, 04, 22), Color.BLUE);
         given(memberService.getMyPageProfile()).willReturn(expected);
 
         //when

--- a/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/owori/domain/member/controller/MemberControllerTest.java
@@ -8,6 +8,7 @@ import com.owori.domain.member.dto.request.MemberRequest;
 import com.owori.domain.member.dto.response.MemberHomeResponse;
 import com.owori.domain.member.dto.response.MemberJwtResponse;
 import com.owori.domain.member.dto.response.MemberProfileResponse;
+import com.owori.domain.member.dto.response.MyPageProfileResponse;
 import com.owori.domain.member.entity.AuthProvider;
 import com.owori.domain.member.entity.Color;
 import com.owori.domain.member.entity.EmotionalBadge;
@@ -235,5 +236,28 @@ class MemberControllerTest extends RestDocsTest {
         // docs
         perform.andDo(print())
                 .andDo(document("find home data", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("마이페이지 유저 조회가 제대로 수행되는가")
+    void findMyPageProfile() throws Exception {
+        //given
+        MyPageProfileResponse expected = new MyPageProfileResponse("꼼지락", LocalDate.of(2000, 04, 22), "red");
+        given(memberService.getMyPageProfile()).willReturn(expected);
+
+        //when
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/members/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
+                                .header("memberId", UUID.randomUUID().toString()));
+
+        //then
+        perform.andExpect(status().isOk());
+
+        //docs
+        perform.andDo(print())
+                .andDo(document("get mypage profile", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
@@ -222,7 +222,7 @@ class MemberServiceTest extends LoginTest {
         //then
         assertThat(response.getBirthday()).isEqualTo(birthday);
         assertThat(response.getNickname()).isEqualTo("지렁이");
-        assertThat(response.getColor()).isEqualTo("PINK");
+        assertThat(response.getColor()).isEqualTo(Color.PINK);
     }
 
 }

--- a/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
@@ -222,7 +222,7 @@ class MemberServiceTest extends LoginTest {
         //then
         assertThat(response.getBirthday()).isEqualTo(birthday);
         assertThat(response.getNickname()).isEqualTo("지렁이");
-        assertThat(response.getMyColor()).isEqualTo("pink");
+        assertThat(response.getColor()).isEqualTo("PINK");
     }
 
 }

--- a/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/owori/domain/member/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import com.owori.domain.member.dto.request.MemberDetailsRequest;
 import com.owori.domain.member.dto.request.MemberProfileRequest;
 import com.owori.domain.member.dto.response.MemberHomeResponse;
 import com.owori.domain.member.dto.response.MemberProfileResponse;
+import com.owori.domain.member.dto.response.MyPageProfileResponse;
 import com.owori.domain.member.entity.*;
 import com.owori.domain.saying.dto.response.SayingByFamilyResponse;
 import com.owori.domain.saying.entity.Saying;
@@ -179,5 +180,22 @@ class MemberServiceTest extends LoginTest {
         assertThat(familyName).isEqualTo(responses.getFamilyGroupName());
         assertThat(responses.getMemberProfiles().stream().map(MemberProfileResponse::getId).toList()).isEqualTo(List.of(authService.getLoginUser().getId(), saveMember1.getId()));
         assertThat(responses.getFamilySayings().stream().map(SayingByFamilyResponse::getId)).hasSameElementsAs(List.of(saying1.getId(), saying2.getId()));
+    }
+
+    @Test
+    @DisplayName("유저 정보 조회가 제대로 이루어지는가")
+    void findMyPageProfile() {
+        //given
+        new Family("우리가족", loginUser, "1231231234");
+        LocalDate birthday = LocalDate.of(2000, 04, 22);
+        loginUser.updateProfile("지렁이", birthday, Color.PINK);
+
+        //when
+        MyPageProfileResponse response = memberService.getMyPageProfile();
+
+        //then
+        assertThat(response.getBirthday()).isEqualTo(birthday);
+        assertThat(response.getNickname()).isEqualTo("지렁이");
+        assertThat(response.getMyColor()).isEqualTo("pink");
     }
 }


### PR DESCRIPTION
Closes #84 

## 추가/수정한 기능 설명
- 마이페이지에 필요한 유저 정보를 가져옵니다. (닉네임, 생년월일, 마이컬러)
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?