### PR TITLE
[REFACTOR] 댓글 삭제 API 수정

### DIFF
--- a/src/main/java/com/owori/domain/comment/entity/Comment.java
+++ b/src/main/java/com/owori/domain/comment/entity/Comment.java
@@ -10,6 +10,8 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,6 +40,9 @@ public class Comment implements Auditable {
     @JoinColumn
     private Comment parent;
 
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+    private List<Comment> children = new ArrayList<>();
+
     @Lob
     @Column(nullable = false)
     private String content;
@@ -59,6 +64,8 @@ public class Comment implements Auditable {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public void deleteComment() { this.content = "삭제된 댓글입니다."; }
 
     public String getTimeBefore() {
         return TimesAgo.of(this.getBaseTime().getCreatedAt());

--- a/src/main/java/com/owori/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/owori/domain/comment/repository/CommentRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
+    Long countByParent(Comment comment);
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. 댓글 삭제 처리 방식 수정
- 하위 댓글 존재하지 않는 댓글일 경우
  -  바로 삭제 -> 삭제로 인하 상위 댓글 삭제 여부 반복문을 통해서 파악
  
- 하위 댓글이 존재하는 댓글일 경우 : 댓글 내용 변경 -> "삭제된 댓글입니다."
<br>


## check list
- [X] issue number를 브랜치 앞에 추가 했나요?
- [X] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [X] 추가/수정사항을 설명했나요?