### PR TITLE
[FIX] 스토리 관련 오류 해결

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,5 +29,13 @@ http{
             proxy_redirect off;
             proxy_pass http://api;
         }
+
+        location ~* (service-worker.js)$ {
+                    default_type  application/octet-stream;
+                    include /etc/nginx/mime.types;
+                    add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+                    expires off;
+                    proxy_no_cache 1;
+        }
     }
 }

--- a/src/main/java/com/owori/domain/member/entity/EmotionalBadge.java
+++ b/src/main/java/com/owori/domain/member/entity/EmotionalBadge.java
@@ -8,7 +8,7 @@ public enum EmotionalBadge {
     HAPPY("행복쓰"),
     SO_HAPPY("엄청 행복쓰"),
     LOVE("사랑해"),
-    SURRISED("놀람"),
+    SURPRISED("놀람"),
     INSIDIOUS("음흉쓰"),
     NORMAL("보통"),
     SLEEPY("졸림"),

--- a/src/main/java/com/owori/domain/story/dto/response/FindAllStoryResponse.java
+++ b/src/main/java/com/owori/domain/story/dto/response/FindAllStoryResponse.java
@@ -17,6 +17,7 @@ public class FindAllStoryResponse {
     private String title;
     private String content;
     private String thumbnail;
+    private Boolean isMultipleImages;
     private Integer heartCount;
     private Integer commentCount;
     private String writer;

--- a/src/main/java/com/owori/domain/story/entity/Story.java
+++ b/src/main/java/com/owori/domain/story/entity/Story.java
@@ -77,11 +77,11 @@ public class Story implements Auditable {
         image.delete();
     }
 
-    public String getMainImage() {
+    public String getMainImage() {  
         if (images.isEmpty()) {
             return null;
         }
-        return images.get(0).getUrl();
+        return getImageUrls().get(0);
     }
 
     public List<String> getImageUrls() {

--- a/src/main/java/com/owori/domain/story/entity/Story.java
+++ b/src/main/java/com/owori/domain/story/entity/Story.java
@@ -88,6 +88,9 @@ public class Story implements Auditable {
         return images.stream().sorted(Comparator.comparing(Image::getOrderNum)).map(Image::getUrl).toList();
     }
 
+    public Boolean isMultipleImages(){
+        return getImageUrls().size() > 1;
+    }
 
     /* comment */
     public void addComment(Comment comment) {

--- a/src/main/java/com/owori/domain/story/mapper/StoryMapper.java
+++ b/src/main/java/com/owori/domain/story/mapper/StoryMapper.java
@@ -31,6 +31,7 @@ public class StoryMapper {
                 .title(story.getTitle())
                 .content(story.getContent())
                 .thumbnail(story.getMainImage())
+                .isMultipleImages(story.isMultipleImages())
                 .heartCount(story.getHearts().size())
                 .commentCount(story.getComments().size())
                 .writer(story.getMember().getNickname())

--- a/src/main/java/com/owori/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/owori/domain/story/repository/StoryRepository.java
@@ -19,9 +19,9 @@ public interface StoryRepository extends JpaRepository<Story, Long>, StoryReposi
     @Query("select s from Story s where s.member.family = :family order by s.baseTime.createdAt DESC ")
     List<Story> findAllByFamilyOrderByCreatedAt(Family family);
 
-    @Query("select s from Story s where s.member.family = :family order by s.startDate DESC")
+    @Query("select s from Story s where s.member.family = :family order by s.startDate, s.baseTime.createdAt DESC")
     List<Story> findAllByFamilyOrderByStartDate(Family family);
 
-    @Query("select s from Story s where s.member = :member order by s.startDate DESC")
+    @Query("select s from Story s where s.member = :member order by s.startDate, s.baseTime.createdAt DESC")
     List<Story> findAllByMember(Member member);
 }

--- a/src/main/java/com/owori/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/owori/domain/story/repository/StoryRepository.java
@@ -19,9 +19,9 @@ public interface StoryRepository extends JpaRepository<Story, Long>, StoryReposi
     @Query("select s from Story s where s.member.family = :family order by s.baseTime.createdAt DESC ")
     List<Story> findAllByFamilyOrderByCreatedAt(Family family);
 
-    @Query("select s from Story s where s.member.family = :family order by s.startDate, s.baseTime.createdAt DESC")
+    @Query("select s from Story s where s.member.family = :family order by s.startDate DESC, s.endDate DESC, s.baseTime.createdAt DESC")
     List<Story> findAllByFamilyOrderByStartDate(Family family);
 
-    @Query("select s from Story s where s.member = :member order by s.startDate, s.baseTime.createdAt DESC")
+    @Query("select s from Story s where s.member = :member order by s.startDate DESC, s.endDate DESC, s.baseTime.createdAt DESC")
     List<Story> findAllByMember(Member member);
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,8 +24,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB
+      max-file-size: 20MB
+      max-request-size: 20MB
 
   main:
     allow-bean-definition-overriding: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,8 +24,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB
+      max-file-size: 20MB
+      max-request-size: 20MB
 
   main:
     allow-bean-definition-overriding: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,8 +22,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB
+      max-file-size: 20MB
+      max-request-size: 20MB
 
   main:
     allow-bean-definition-overriding: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -24,8 +24,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB
+      max-file-size: 20MB
+      max-request-size: 20MB
 
   h2:
     console:

--- a/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
+++ b/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
@@ -98,10 +98,10 @@ class StoryControllerTest extends RestDocsTest{
     void findAllStoryByEventAt() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(
-                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
-                new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)));
+                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
+                new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)));
 
         FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
         given(storyService.findAllStory(any(),any())).willReturn(findAllStoryGroupResponse);
@@ -130,10 +130,10 @@ class StoryControllerTest extends RestDocsTest{
     void findAllStoryByCreatedAt() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(
-                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)),
-                new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
-                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)));
+                new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)),
+                new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png",Boolean.FALSE, 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
+                new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)));
 
         FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
         given(storyService.findAllStory(any(),any())).willReturn(findAllStoryGroupResponse);
@@ -170,7 +170,7 @@ class StoryControllerTest extends RestDocsTest{
                 new CommentResponse(null, UUID.randomUUID(),"야호 두번째 최상위댓글입니다.","아몬드","2시간 전", Boolean.FALSE)
         );
 
-        FindStoryResponse response = new FindStoryResponse(UUID.randomUUID(),true, images, "~ 다같이 야구 보고온 날 ~", "김건빵", "오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 얏호", 5, 4, comments, LocalDate.now(), LocalDate.now());
+        FindStoryResponse response = new FindStoryResponse(UUID.randomUUID(),true, images, "~ 다같이 야구 보고온 날 ~", "김건빵", "오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 오늘은 엘지가 이겼다. 얏호", 5, 4, comments, LocalDate.now(), LocalDate.now(), "image2.png");
         given(facadeService.findStory(any())).willReturn(response);
 
         //when
@@ -219,10 +219,10 @@ class StoryControllerTest extends RestDocsTest{
     void findStoryBySearch() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(
-                new FindAllStoryResponse(UUID.randomUUID(),"룰루랄라", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03)),
-                new FindAllStoryResponse(UUID.randomUUID(),"생일잔치", "못난이 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 1, 0, "허망고", LocalDate.of(2011, 02, 01), LocalDate.of(2011, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"쇼핑 데이 with 못난이", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 3, "못난이", LocalDate.of(2010, 02, 01), LocalDate.of(2022, 12, 03)));
+                new FindAllStoryResponse(UUID.randomUUID(),"룰루랄라", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03)),
+                new FindAllStoryResponse(UUID.randomUUID(),"생일잔치", "못난이 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 1, 0, "허망고", LocalDate.of(2011, 02, 01), LocalDate.of(2011, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"쇼핑 데이 with 못난이", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 3, "못난이", LocalDate.of(2010, 02, 01), LocalDate.of(2022, 12, 03)));
 
         FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, false);
         given(storyService.findStoryBySearch(any(),any(), any())).willReturn(findAllStoryGroupResponse);
@@ -252,8 +252,8 @@ class StoryControllerTest extends RestDocsTest{
     void findStoryByMember() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(
-                new FindAllStoryResponse(UUID.randomUUID(),"룰루랄라", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03)));
+                new FindAllStoryResponse(UUID.randomUUID(),"룰루랄라", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03)));
         FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, false);
         given(storyService.findStoryByWriter(any(),any())).willReturn(findAllStoryGroupResponse);
 
@@ -281,8 +281,8 @@ class StoryControllerTest extends RestDocsTest{
     void findStoryByHeart() throws Exception {
         //given
         List<FindAllStoryResponse> response = List.of(
-                new FindAllStoryResponse(UUID.randomUUID(),"선풍기 청소한 날", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
-                new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03))
+                new FindAllStoryResponse(UUID.randomUUID(),"선풍기 청소한 날", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png",  Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
+                new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03))
         );
         FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
         given(storyService.findStoryByHeart(any(),any())).willReturn(findAllStoryGroupResponse);


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. 당일 날짜 설정 시 스토리 생성 안되는 에러 해결
2. 스토리 조회 시, 고화질 사진일 시 전송 안되는 에러 해결
- multipart 최대 크기 10MB -> 20MB로 변경
3. 생성 이후 조회 시 즉시 조회가 안되는 에러 해결
- nginx.conf 일부 코드 추가
4. 뱃지 필드명 오타 수정 완료
5.스토리 전체조회 시 다중 이미지 여부 필드 추가
- 스토리 전체 조회에서 isMultipleImages 필드 추가
6. 스토리 이미지 순서 및 썸네일 조회 수정 완료

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?