### PR TITLE
[REFACTOR] 무한 스크롤 구현 방식 수정

### DIFF
--- a/src/main/java/com/owori/domain/story/controller/StoryController.java
+++ b/src/main/java/com/owori/domain/story/controller/StoryController.java
@@ -5,12 +5,12 @@ import com.owori.domain.story.dto.request.UpdateStoryRequest;
 import com.owori.domain.story.dto.response.FindAllStoryGroupResponse;
 import com.owori.domain.story.dto.response.FindStoryResponse;
 import com.owori.domain.story.dto.response.StoryIdResponse;
+import com.owori.domain.story.dto.response.StoryPagingResponse;
 import com.owori.domain.story.service.FacadeService;
 import com.owori.domain.story.service.StoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
-import java.time.LocalDate;
 import java.util.UUID;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
@@ -33,6 +32,45 @@ public class StoryController {
     private final FacadeService facadeService;
 
     /**
+     * todo : 다음 배포 시 삭제
+     * 이야기를 전체 조회를 위한 컨트롤러입니다.
+     * @param sort 정렬 조건입니다.
+     * @return 전체 조회 dto가 반환됩니다.
+     */
+    @GetMapping("/find")
+    public ResponseEntity<FindAllStoryGroupResponse> findAllStory2(@RequestParam(value = "sort") String sort) {
+        return ResponseEntity.ok(storyService.findAllStory2(sort));
+    }
+
+    // * todo : 다음 배포 시 삭제
+    @GetMapping("/search/temp")
+    public ResponseEntity<FindAllStoryGroupResponse> findStoryBySearch2(
+            @RequestParam @Size(min = 2, message = "검색어를 2글자 이상 입력해주세요.") String keyword,
+            @RequestParam(value = "sort") String sort) {
+        return ResponseEntity.ok(storyService.findStoryBySearch2(keyword, sort));
+    }
+
+    /**
+     * todo: 다음 배포 시 삭제
+     * 유저가 작성한 이야기 조회를 위한 임시 컨트롤러입니다.
+     * @return 전체 조회 dto가 반환됩니다.
+     */
+    @GetMapping("/member/find")
+    public ResponseEntity<FindAllStoryGroupResponse> findStoryByWriter2() {
+        return ResponseEntity.ok(storyService.findStoryByWriter2());
+    }
+
+    /**
+     * todo: 다음 배포 시 삭제
+     * 유저가 작성한 좋아한 조회를 위한 임시 컨트롤러입니다.
+     * @return 전체 조회 dto가 반환됩니다.
+     */
+    @GetMapping("/heart/find")
+    public ResponseEntity<FindAllStoryGroupResponse> findStoryByHeart2() {
+        return ResponseEntity.ok(storyService.findStoryByHeart2());
+    }
+
+    /**
      * 이야기를 생성합니다.
      * @param request 이야기 생성을 위한 dto 입니다.
      * @return 생성된 이야기의 id가 반환됩니다.
@@ -43,49 +81,27 @@ public class StoryController {
     }
 
     /**
-     * 이야기를 전체 조회를 위한 컨트롤러입니다.
+     * 페이징을 사용한 이야기를 전체 조회를 위한 컨트롤러입니다.
      * @param pageable
-     * @param lastViewed 조회할 게시글의 기준 (year_month) 입니다.
      * @return 전체 조회 dto가 반환됩니다.
      */
     @GetMapping
-    public ResponseEntity<FindAllStoryGroupResponse> findAllStory(
-            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable,
-            @RequestParam(required = false, value = "last_viewed") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed) {
-
-        return ResponseEntity.ok(storyService.findAllStory(pageable, lastViewed));
-    }
-
-    /**
-     * 이야기를 전체 조회를 위한 임시 컨트롤러입니다.
-     * @param sort 정렬 조건입니다.
-     * @return 전체 조회 dto가 반환됩니다.
-     */
-    @GetMapping("/find")
-    public ResponseEntity<FindAllStoryGroupResponse> findAllStory2(@RequestParam(value = "sort") String sort) {
-        return ResponseEntity.ok(storyService.findAllStory2(sort));
+    public ResponseEntity<StoryPagingResponse> findAllStory(
+            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable) {
+        return ResponseEntity.ok(storyService.findAllStory(pageable));
     }
 
     /**
      * 이야기 검색을 위한 컨트롤러입니다.
      * @param keyword    검색어입니다.
-     * @param lastViewed
      * @param pageable
      * @return 검색 결과 dto가 반환됩니다.
      */
     @GetMapping("/search")
-    public ResponseEntity<FindAllStoryGroupResponse> findStoryBySearch(
-            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable,
-            @RequestParam("last_viewed") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed,
-            @RequestParam @Size(min = 2, message = "검색어를 2글자 이상 입력해주세요.") String keyword) {
-        return ResponseEntity.ok(storyService.findStoryBySearch(keyword, pageable, lastViewed));
-    }
-
-    @GetMapping("/search/temp")
-    public ResponseEntity<FindAllStoryGroupResponse> findStoryBySearch2(
+    public ResponseEntity<StoryPagingResponse> findStoryBySearch(
             @RequestParam @Size(min = 2, message = "검색어를 2글자 이상 입력해주세요.") String keyword,
-            @RequestParam(value = "sort") String sort) {
-        return ResponseEntity.ok(storyService.findStoryBySearch2(keyword, sort));
+            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable) {
+        return ResponseEntity.ok(storyService.findStoryBySearch(keyword, pageable));
     }
 
     /**
@@ -94,41 +110,22 @@ public class StoryController {
      * @return 전체 조회 dto가 반환됩니다.
      */
     @GetMapping("/member")
-    public ResponseEntity<FindAllStoryGroupResponse> findStoryByWriter(
-            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable,
-            @RequestParam(required = false, value = "last_viewed") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed) {
+    public ResponseEntity<StoryPagingResponse> findStoryByWriter(
+            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable) {
 
-        return ResponseEntity.ok(storyService.findStoryByWriter(pageable, lastViewed));
+        return ResponseEntity.ok(storyService.findStoryByWriter(pageable));
     }
 
-    /**
-     * 유저가 작성한 이야기 조회를 위한 임시 컨트롤러입니다.
-     * @return 전체 조회 dto가 반환됩니다.
-     */
-    @GetMapping("/member/find")
-    public ResponseEntity<FindAllStoryGroupResponse> findStoryByWriter2() {
-        return ResponseEntity.ok(storyService.findStoryByWriter2());
-    }
     /**
      * 유저가 작성한 좋아한 조회를 위한 컨트롤러입니다.
      * @param pageable
      * @return 전체 조회 dto가 반환됩니다.
      */
     @GetMapping("/heart")
-    public ResponseEntity<FindAllStoryGroupResponse> findStoryByHeart(
-            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable,
-            @RequestParam(required = false, value = "last_viewed") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lastViewed) {
+    public ResponseEntity<StoryPagingResponse> findStoryByHeart(
+            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable) {
 
-        return ResponseEntity.ok(storyService.findStoryByHeart(pageable, lastViewed));
-    }
-
-    /**
-     * 유저가 작성한 좋아한 조회를 위한 임시 컨트롤러입니다.
-     * @return 전체 조회 dto가 반환됩니다.
-     */
-    @GetMapping("/heart/find")
-    public ResponseEntity<FindAllStoryGroupResponse> findStoryByHeart2() {
-        return ResponseEntity.ok(storyService.findStoryByHeart2());
+        return ResponseEntity.ok(storyService.findStoryByHeart(pageable));
     }
 
     /**

--- a/src/main/java/com/owori/domain/story/dto/response/FindAllStoryGroupResponse.java
+++ b/src/main/java/com/owori/domain/story/dto/response/FindAllStoryGroupResponse.java
@@ -8,6 +8,8 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class FindAllStoryGroupResponse {
+    // todo: 다음 버전 배포 시 삭제
+
     private List<FindAllStoryResponse> stories;
     private Boolean hasNext;
 }

--- a/src/main/java/com/owori/domain/story/dto/response/StoryPagingResponse.java
+++ b/src/main/java/com/owori/domain/story/dto/response/StoryPagingResponse.java
@@ -1,0 +1,46 @@
+package com.owori.domain.story.dto.response;
+
+import com.owori.domain.story.entity.Story;
+import com.owori.domain.story.mapper.StoryMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoryPagingResponse {
+    private static final StoryMapper storyMapper = new StoryMapper();
+    private static final Integer LAST_PAGE = -1;
+
+    private List<FindAllStoryResponse> contents = new ArrayList<>();
+    private Integer lastPage;
+    private Integer nextPage;
+
+
+    public static StoryPagingResponse of(Page<Story> pageStory){
+        if(!pageStory.hasNext()){
+            return StoryPagingResponse.newLastScroll(pageStory.getContent(), pageStory.getTotalPages() - 1);
+        }
+        return StoryPagingResponse.newPageHasNext(pageStory.getContent(), pageStory.getTotalPages() - 1, pageStory.getPageable().getPageNumber() + 1);
+    }
+
+    private static StoryPagingResponse newPageHasNext(List<Story> stories, Integer lastPage, Integer nextPage) {
+        return new StoryPagingResponse(getContents(stories), lastPage, nextPage);
+    }
+
+    private static StoryPagingResponse newLastScroll(List<Story> stories, Integer lastPage) {
+        return newPageHasNext(stories, lastPage, LAST_PAGE);
+    }
+
+    private static List<FindAllStoryResponse> getContents(List<Story> stories){
+        return stories.stream().map(story -> storyMapper.toFindAllStoryResponse(story)).toList();
+    }
+
+
+}

--- a/src/main/java/com/owori/domain/story/dto/response/StoryPagingResponse.java
+++ b/src/main/java/com/owori/domain/story/dto/response/StoryPagingResponse.java
@@ -18,7 +18,7 @@ public class StoryPagingResponse {
     private static final StoryMapper storyMapper = new StoryMapper();
     private static final Integer LAST_PAGE = -1;
 
-    private List<FindAllStoryResponse> contents = new ArrayList<>();
+    private List<FindAllStoryResponse> stories = new ArrayList<>();
     private Integer nextPage;
     private Integer lastPage;
 

--- a/src/main/java/com/owori/domain/story/dto/response/StoryPagingResponse.java
+++ b/src/main/java/com/owori/domain/story/dto/response/StoryPagingResponse.java
@@ -19,8 +19,9 @@ public class StoryPagingResponse {
     private static final Integer LAST_PAGE = -1;
 
     private List<FindAllStoryResponse> contents = new ArrayList<>();
-    private Integer lastPage;
     private Integer nextPage;
+    private Integer lastPage;
+
 
 
     public static StoryPagingResponse of(Page<Story> pageStory){

--- a/src/main/java/com/owori/domain/story/repository/StoryRepositoryCustom.java
+++ b/src/main/java/com/owori/domain/story/repository/StoryRepositoryCustom.java
@@ -3,16 +3,15 @@ package com.owori.domain.story.repository;
 import com.owori.domain.family.entity.Family;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.story.entity.Story;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface StoryRepositoryCustom {
-    Slice<Story> findAllStory(Pageable pageable, Family family, LocalDate date);
-    Slice<Story> findStoryBySearch(Pageable pageable, String keyword, Family family, LocalDate date);
-    Slice<Story> findStoryByWriter(Pageable pageable, Member member, LocalDate date);
-    Slice<Story> findStoryByHeart(Pageable pageable, Member member, LocalDate date);
+    Page<Story> findStoryBySearch(Pageable pageable, String keyword, Family family);
+    Page<Story> findStoryByWriter(Pageable pageable, Member member);
+    Page<Story> findStoryByHeart(Pageable pageable, Member member);
     List<Story> findStoryBySearch2(String keyword, Family family);
+    Page<Story> findAllStory(Pageable pageable, Family family);
 }

--- a/src/main/java/com/owori/domain/story/service/StoryService.java
+++ b/src/main/java/com/owori/domain/story/service/StoryService.java
@@ -7,12 +7,12 @@ import com.owori.domain.image.service.ImageService;
 import com.owori.domain.keyword.service.KeywordService;
 import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
-import com.owori.domain.schedule.entity.Schedule;
 import com.owori.domain.story.dto.request.PostStoryRequest;
 import com.owori.domain.story.dto.request.UpdateStoryRequest;
 import com.owori.domain.story.dto.response.FindAllStoryGroupResponse;
 import com.owori.domain.story.dto.response.FindStoryResponse;
 import com.owori.domain.story.dto.response.StoryIdResponse;
+import com.owori.domain.story.dto.response.StoryPagingResponse;
 import com.owori.domain.story.entity.Story;
 import com.owori.domain.story.mapper.StoryMapper;
 import com.owori.domain.story.repository.StoryRepository;
@@ -22,13 +22,10 @@ import com.owori.global.exception.NoAuthorityException;
 import com.owori.global.service.EntityLoader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -59,10 +56,9 @@ public class StoryService implements EntityLoader<Story, UUID> {
     }
 
     @Transactional(readOnly = true)
-    public FindAllStoryGroupResponse findAllStory(Pageable pageable, LocalDate lastViewed) {
+    public StoryPagingResponse findAllStory(Pageable pageable) {
         Family family = authService.getLoginUser().getFamily();
-        Slice<Story> storyBySlice = storyRepository.findAllStory(pageable, family, lastViewed);
-        return storyMapper.toFindAllStoryGroupResponse(storyBySlice);
+        return StoryPagingResponse.of(storyRepository.findAllStory(pageable, family));
     }
 
     public FindAllStoryGroupResponse findAllStory2(String sort) {
@@ -104,12 +100,11 @@ public class StoryService implements EntityLoader<Story, UUID> {
         story.delete(); // 스토리 삭제
     }
 
-    public FindAllStoryGroupResponse findStoryBySearch(String keyword, Pageable pageable, LocalDate lastViewed) {
+    public StoryPagingResponse findStoryBySearch(String keyword, Pageable pageable) {
         Member loginUser = authService.getLoginUser();
-        Slice<Story> storyBySearch = storyRepository.findStoryBySearch(pageable, keyword, loginUser.getFamily(), lastViewed);
         keywordService.addKeyword(keyword, loginUser);
 
-        return storyMapper.toFindAllStoryGroupResponse(storyBySearch);
+        return StoryPagingResponse.of(storyRepository.findStoryBySearch(pageable, keyword, loginUser.getFamily()));
     }
 
     public FindAllStoryGroupResponse findStoryBySearch2(String keyword, String sort) {
@@ -120,11 +115,9 @@ public class StoryService implements EntityLoader<Story, UUID> {
     }
 
     @Transactional(readOnly = true)
-    public FindAllStoryGroupResponse findStoryByWriter(Pageable pageable, LocalDate lastViewed) {
+    public StoryPagingResponse findStoryByWriter(Pageable pageable) {
         Member member = authService.getLoginUser();
-        Slice<Story> storyByWriter = storyRepository.findStoryByWriter(pageable, member, lastViewed);
-
-        return storyMapper.toFindAllStoryGroupResponse(storyByWriter);
+        return StoryPagingResponse.of(storyRepository.findStoryByWriter(pageable, member));
     }
 
     public FindAllStoryGroupResponse findStoryByWriter2() {
@@ -135,11 +128,9 @@ public class StoryService implements EntityLoader<Story, UUID> {
     }
 
     @Transactional(readOnly = true)
-    public FindAllStoryGroupResponse findStoryByHeart(Pageable pageable, LocalDate lastViewed) {
+    public StoryPagingResponse findStoryByHeart(Pageable pageable) {
         Member member = authService.getLoginUser();
-        Slice<Story> storyByHeart = storyRepository.findStoryByHeart(pageable, member, lastViewed);
-
-        return storyMapper.toFindAllStoryGroupResponse(storyByHeart);
+        return StoryPagingResponse.of(storyRepository.findStoryByHeart(pageable, member));
     }
 
     public FindAllStoryGroupResponse findStoryByHeart2() {

--- a/src/test/java/com/owori/domain/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/com/owori/domain/keyword/service/KeywordServiceTest.java
@@ -52,9 +52,9 @@ public class KeywordServiceTest extends LoginTest {
         storyRepository.save(story);
 
         //when
-        storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("created_at")), null);
-        storyService.findStoryBySearch("우리집", PageRequest.of(0, 4, Sort.by("created_at")), null);
-        storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("created_at")), null);
+        storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("created_at")));
+        storyService.findStoryBySearch("우리집", PageRequest.of(0, 4, Sort.by("created_at")));
+        storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("created_at")));
 
         List<Keyword> keywords = keywordRepository.findByMember(member);
 
@@ -77,9 +77,9 @@ public class KeywordServiceTest extends LoginTest {
         storyRepository.save(story);
 
         //when
-        storyService.findStoryBySearch("야호", PageRequest.of(0, 4, Sort.by("created_at")), null);
-        storyService.findStoryBySearch("우리집", PageRequest.of(0, 4, Sort.by("created_at")), null);
-        storyService.findStoryBySearch("야호", PageRequest.of(0, 4, Sort.by("created_at")), null);
+        storyService.findStoryBySearch("야호", PageRequest.of(0, 4, Sort.by("created_at")));
+        storyService.findStoryBySearch("우리집", PageRequest.of(0, 4, Sort.by("created_at")));
+        storyService.findStoryBySearch("야호", PageRequest.of(0, 4, Sort.by("created_at")));
 
         List<FindKeywordsResponse> searchWords = keywordService.findSearchWords();
 

--- a/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
+++ b/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
@@ -3,13 +3,9 @@ package com.owori.domain.story.controller;
 import com.owori.domain.comment.dto.response.CommentResponse;
 import com.owori.domain.story.dto.request.PostStoryRequest;
 import com.owori.domain.story.dto.request.UpdateStoryRequest;
-import com.owori.domain.story.dto.response.FindAllStoryGroupResponse;
-import com.owori.domain.story.dto.response.FindAllStoryResponse;
-import com.owori.domain.story.dto.response.FindStoryResponse;
-import com.owori.domain.story.dto.response.StoryIdResponse;
+import com.owori.domain.story.dto.response.*;
 import com.owori.domain.story.service.FacadeService;
 import com.owori.domain.story.service.StoryService;
-import com.owori.global.dto.ImageResponse;
 import com.owori.support.docs.RestDocsTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +17,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static com.owori.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.owori.support.docs.ApiDocsUtils.getDocumentResponse;
@@ -103,15 +98,16 @@ class StoryControllerTest extends RestDocsTest{
                 new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)));
 
-        FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
-        given(storyService.findAllStory(any(),any())).willReturn(findAllStoryGroupResponse);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 4,2);
+        given(storyService.findAllStory(any())).willReturn(pagingResponse);
 
         //when
         ResultActions perform =
                 mockMvc.perform(
                         get("/stories")
                                 .param("sort", "start_date")
-                                .param("last_viewed","2022-03-31")
+                                .param("page","1")
+                                .param("size","4")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
                                 .header("member_id", UUID.randomUUID().toString())
@@ -135,15 +131,16 @@ class StoryControllerTest extends RestDocsTest{
                 new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
                 new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)));
 
-        FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
-        given(storyService.findAllStory(any(),any())).willReturn(findAllStoryGroupResponse);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 4,2);
+        given(storyService.findAllStory(any())).willReturn(pagingResponse);
 
         //when
         ResultActions perform =
                 mockMvc.perform(
                         get("/stories")
                                 .param("sort", "created_at")
-                                .param("last_viewed","2023-08-31")
+                                .param("page","1")
+                                .param("size","4")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
                                 .header("member_id", UUID.randomUUID().toString())
@@ -224,15 +221,16 @@ class StoryControllerTest extends RestDocsTest{
                 new FindAllStoryResponse(UUID.randomUUID(),"생일잔치", "못난이 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 1, 0, "허망고", LocalDate.of(2011, 02, 01), LocalDate.of(2011, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"쇼핑 데이 with 못난이", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 3, "못난이", LocalDate.of(2010, 02, 01), LocalDate.of(2022, 12, 03)));
 
-        FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, false);
-        given(storyService.findStoryBySearch(any(),any(), any())).willReturn(findAllStoryGroupResponse);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 10, -1);
+        given(storyService.findStoryBySearch(any(),any())).willReturn(pagingResponse);
 
         //when
         ResultActions perform =
                 mockMvc.perform(
                         get("/stories/search")
                                 .param("keyword", "못난이")
-                                .param("last_viewed","2023-08-31")
+                                .param("page", "10")
+                                .param("size", "4")
                                 .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
                                 .header("member_id", UUID.randomUUID().toString())
                                 .characterEncoding("UTF-8")
@@ -254,15 +252,16 @@ class StoryControllerTest extends RestDocsTest{
         List<FindAllStoryResponse> response = List.of(
                 new FindAllStoryResponse(UUID.randomUUID(),"룰루랄라", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03)));
-        FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, false);
-        given(storyService.findStoryByWriter(any(),any())).willReturn(findAllStoryGroupResponse);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 21, 12);
+        given(storyService.findStoryByWriter(any())).willReturn(pagingResponse);
 
         //when
         ResultActions perform =
                 mockMvc.perform(
                         get("/stories/member")
                                 .param("sort", "start_date")
-                                .param("last_viewed","2023-08-31")
+                                .param("page","11")
+                                .param("size", "2")
                                 .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
                                 .header("member_id", UUID.randomUUID().toString())
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -284,15 +283,16 @@ class StoryControllerTest extends RestDocsTest{
                 new FindAllStoryResponse(UUID.randomUUID(),"선풍기 청소한 날", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png",  Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03))
         );
-        FindAllStoryGroupResponse findAllStoryGroupResponse = new FindAllStoryGroupResponse(response, true);
-        given(storyService.findStoryByHeart(any(),any())).willReturn(findAllStoryGroupResponse);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 12, 2);
+        given(storyService.findStoryByHeart(any())).willReturn(pagingResponse);
 
         //when
         ResultActions perform =
                 mockMvc.perform(
                         get("/stories/heart")
                                 .param("sort", "created_at")
-                                .param("last_viewed","2023-08-31")
+                                .param("page","1")
+                                .param("size", "2")
                                 .header("Authorization", "Bearer ghuriewhv32j12.oiuwhftg32shdi.ogiurhw0gb")
                                 .header("member_id", UUID.randomUUID().toString())
                                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
+++ b/src/test/java/com/owori/domain/story/controller/StoryControllerTest.java
@@ -98,7 +98,7 @@ class StoryControllerTest extends RestDocsTest{
                 new FindAllStoryResponse(UUID.randomUUID(),"못난이 생일잔치", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 1, 0, "허망고", LocalDate.of(2012, 02, 01), LocalDate.of(2012, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"다같이 보드게임 했던 날", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용 이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 3, "허지롱이", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 12, 03)));
 
-        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 4,2);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 2,4);
         given(storyService.findAllStory(any())).willReturn(pagingResponse);
 
         //when
@@ -131,7 +131,7 @@ class StoryControllerTest extends RestDocsTest{
                 new FindAllStoryResponse(UUID.randomUUID(),"맛있는 저녁식사", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2005, 02, 03)),
                 new FindAllStoryResponse(UUID.randomUUID(),"신나는 가족여행", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.TRUE, 2, 2, "고구마", LocalDate.of(2002, 02, 01), LocalDate.of(2002, 02, 02)));
 
-        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 4,2);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 2,4);
         given(storyService.findAllStory(any())).willReturn(pagingResponse);
 
         //when
@@ -252,7 +252,7 @@ class StoryControllerTest extends RestDocsTest{
         List<FindAllStoryResponse> response = List.of(
                 new FindAllStoryResponse(UUID.randomUUID(),"룰루랄라", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png", Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03)));
-        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 21, 12);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 12, 21);
         given(storyService.findStoryByWriter(any())).willReturn(pagingResponse);
 
         //when
@@ -283,7 +283,7 @@ class StoryControllerTest extends RestDocsTest{
                 new FindAllStoryResponse(UUID.randomUUID(),"선풍기 청소한 날", "이야기 내용입니다 못난이 내용 내용 내용 내용 내용 내용 내용 내용 내용", "https://owori.s3.ap-northeast-2.amazonaws.com/story/Group%2010_f985a58a-1257-4691-88ee-e2b75977fb3e.png",  Boolean.FALSE, 2, 2, "고구마", LocalDate.of(2022, 02, 01), LocalDate.of(2022, 02, 02)),
                 new FindAllStoryResponse(UUID.randomUUID(),"못난이 외식 했지롱", "이야기 내용입니다 내용 내용 내용 내용 내용 내용 내용 내용 내용", null, Boolean.FALSE, 0, 0, "구운계란", LocalDate.of(2005, 02, 01), LocalDate.of(2019, 02, 03))
         );
-        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 12, 2);
+        StoryPagingResponse pagingResponse = new StoryPagingResponse(response, 2, 12);
         given(storyService.findStoryByHeart(any())).willReturn(pagingResponse);
 
         //when

--- a/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
+++ b/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
@@ -13,9 +13,9 @@ import com.owori.domain.member.entity.Member;
 import com.owori.domain.member.service.AuthService;
 import com.owori.domain.story.dto.request.PostStoryRequest;
 import com.owori.domain.story.dto.request.UpdateStoryRequest;
-import com.owori.domain.story.dto.response.FindAllStoryGroupResponse;
 import com.owori.domain.story.dto.response.FindStoryResponse;
 import com.owori.domain.story.dto.response.StoryIdResponse;
+import com.owori.domain.story.dto.response.StoryPagingResponse;
 import com.owori.domain.story.entity.Story;
 import com.owori.domain.story.repository.StoryRepository;
 import com.owori.global.exception.EntityNotFoundException;
@@ -80,12 +80,12 @@ public class StoryServiceTest extends LoginTest {
         heartRepository.save(new Heart(member, story));
 
         //when
-        FindAllStoryGroupResponse response = storyService.findAllStory(PageRequest.of(0, 4, Sort.by("created_at")), null);
+        StoryPagingResponse response = storyService.findAllStory(PageRequest.of(0, 4, Sort.by("created_at")));
 
         //then
-        assertThat(response.getStories().get(0).getTitle()).isEqualTo(title);
-        assertThat(response.getStories().get(0).getCommentCount()).isEqualTo(1);
-        assertThat(response.getStories().get(0).getHeartCount()).isEqualTo(1);
+        assertThat(response.getContents().get(0).getTitle()).isEqualTo(title);
+        assertThat(response.getContents().get(0).getCommentCount()).isEqualTo(1);
+        assertThat(response.getContents().get(0).getHeartCount()).isEqualTo(1);
     }
 
     @Test
@@ -107,14 +107,14 @@ public class StoryServiceTest extends LoginTest {
         image.updateStory(story);
 
         //when
-        FindAllStoryGroupResponse response = storyService.findAllStory(PageRequest.of(0, 4, Sort.by("start_date")), null);
+        StoryPagingResponse response = storyService.findAllStory(PageRequest.of(0, 4, Sort.by("start_date")));
 
         //then
-        assertThat(response.getStories().get(0).getTitle()).isEqualTo("기다리고 기다리던 하루");
-        assertThat(response.getStories().get(0).getCommentCount()).isEqualTo(1);
-        assertThat(response.getStories().get(0).getHeartCount()).isEqualTo(1);
-        assertThat(response.getStories().get(1).getContent()).isEqualTo("내용2");
-        assertThat(response.getStories().get(0).getThumbnail()).isEqualTo("a.png");
+        assertThat(response.getContents().get(0).getTitle()).isEqualTo("기다리고 기다리던 하루");
+        assertThat(response.getContents().get(0).getCommentCount()).isEqualTo(1);
+        assertThat(response.getContents().get(0).getHeartCount()).isEqualTo(1);
+        assertThat(response.getContents().get(1).getContent()).isEqualTo("내용2");
+        assertThat(response.getContents().get(0).getThumbnail()).isEqualTo("a.png");
     }
 
     @Test
@@ -210,13 +210,13 @@ public class StoryServiceTest extends LoginTest {
         storyRepository.save(story3);
 
         //when
-        FindAllStoryGroupResponse response = storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("created_at")), null);
+        StoryPagingResponse response = storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("created_at")));
 
         //then
-        assertThat(response.getStories()).hasSize(2);
-        assertThat(response.getStories().get(0).getContent()).isEqualTo("내용 기다리고");
-        assertThat(response.getStories().get(0).getWriter()).isEqualTo("파인애플");
-        assertThat(response.getStories().get(1).getTitle()).isEqualTo("기다리고 기다리던 하루");
+        assertThat(response.getContents()).hasSize(2);
+        assertThat(response.getContents().get(0).getContent()).isEqualTo("내용 기다리고");
+        assertThat(response.getContents().get(0).getWriter()).isEqualTo("파인애플");
+        assertThat(response.getContents().get(1).getTitle()).isEqualTo("기다리고 기다리던 하루");
     }
 
     @Test
@@ -232,12 +232,12 @@ public class StoryServiceTest extends LoginTest {
         storyRepository.save(story3);
 
         //when
-        FindAllStoryGroupResponse response = storyService.findStoryByWriter( PageRequest.of(0, 4, Sort.by("created_at")), null);
+        StoryPagingResponse response = storyService.findStoryByWriter(PageRequest.of(0, 4, Sort.by("created_at")));
 
         //then
-        assertThat(response.getStories()).hasSize(1);
-        assertThat(response.getStories().get(0).getContent()).isEqualTo("정답");
-        assertThat(response.getStories().get(0).getWriter()).isEqualTo("파인애플");
+        assertThat(response.getContents()).hasSize(1);
+        assertThat(response.getContents().get(0).getContent()).isEqualTo("정답");
+        assertThat(response.getContents().get(0).getWriter()).isEqualTo("파인애플");
     }
 
     @Test
@@ -256,11 +256,11 @@ public class StoryServiceTest extends LoginTest {
         heartRepository.save(new Heart(member, story2));
 
         //when
-        FindAllStoryGroupResponse response = storyService.findStoryByHeart( PageRequest.of(0, 4, Sort.by("start_date")), null);
+        StoryPagingResponse response = storyService.findStoryByHeart(PageRequest.of(0, 4, Sort.by("start_date")));
 
         //then
-        assertThat(response.getStories()).hasSize(1);
-        assertThat(response.getStories().get(0).getContent()).isEqualTo("정답");
-        assertThat(response.getStories().get(0).getTitle()).isEqualTo("좋아요");
+        assertThat(response.getContents()).hasSize(1);
+        assertThat(response.getContents().get(0).getContent()).isEqualTo("정답");
+        assertThat(response.getContents().get(0).getTitle()).isEqualTo("좋아요");
     }
 }

--- a/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
+++ b/src/test/java/com/owori/domain/story/service/StoryServiceTest.java
@@ -83,9 +83,9 @@ public class StoryServiceTest extends LoginTest {
         StoryPagingResponse response = storyService.findAllStory(PageRequest.of(0, 4, Sort.by("created_at")));
 
         //then
-        assertThat(response.getContents().get(0).getTitle()).isEqualTo(title);
-        assertThat(response.getContents().get(0).getCommentCount()).isEqualTo(1);
-        assertThat(response.getContents().get(0).getHeartCount()).isEqualTo(1);
+        assertThat(response.getStories().get(0).getTitle()).isEqualTo(title);
+        assertThat(response.getStories().get(0).getCommentCount()).isEqualTo(1);
+        assertThat(response.getStories().get(0).getHeartCount()).isEqualTo(1);
     }
 
     @Test
@@ -110,11 +110,11 @@ public class StoryServiceTest extends LoginTest {
         StoryPagingResponse response = storyService.findAllStory(PageRequest.of(0, 4, Sort.by("start_date")));
 
         //then
-        assertThat(response.getContents().get(0).getTitle()).isEqualTo("기다리고 기다리던 하루");
-        assertThat(response.getContents().get(0).getCommentCount()).isEqualTo(1);
-        assertThat(response.getContents().get(0).getHeartCount()).isEqualTo(1);
-        assertThat(response.getContents().get(1).getContent()).isEqualTo("내용2");
-        assertThat(response.getContents().get(0).getThumbnail()).isEqualTo("a.png");
+        assertThat(response.getStories().get(0).getTitle()).isEqualTo("기다리고 기다리던 하루");
+        assertThat(response.getStories().get(0).getCommentCount()).isEqualTo(1);
+        assertThat(response.getStories().get(0).getHeartCount()).isEqualTo(1);
+        assertThat(response.getStories().get(1).getContent()).isEqualTo("내용2");
+        assertThat(response.getStories().get(0).getThumbnail()).isEqualTo("a.png");
     }
 
     @Test
@@ -213,10 +213,10 @@ public class StoryServiceTest extends LoginTest {
         StoryPagingResponse response = storyService.findStoryBySearch("기다리", PageRequest.of(0, 4, Sort.by("created_at")));
 
         //then
-        assertThat(response.getContents()).hasSize(2);
-        assertThat(response.getContents().get(0).getContent()).isEqualTo("내용 기다리고");
-        assertThat(response.getContents().get(0).getWriter()).isEqualTo("파인애플");
-        assertThat(response.getContents().get(1).getTitle()).isEqualTo("기다리고 기다리던 하루");
+        assertThat(response.getStories()).hasSize(2);
+        assertThat(response.getStories().get(0).getContent()).isEqualTo("내용 기다리고");
+        assertThat(response.getStories().get(0).getWriter()).isEqualTo("파인애플");
+        assertThat(response.getStories().get(1).getTitle()).isEqualTo("기다리고 기다리던 하루");
     }
 
     @Test
@@ -235,9 +235,9 @@ public class StoryServiceTest extends LoginTest {
         StoryPagingResponse response = storyService.findStoryByWriter(PageRequest.of(0, 4, Sort.by("created_at")));
 
         //then
-        assertThat(response.getContents()).hasSize(1);
-        assertThat(response.getContents().get(0).getContent()).isEqualTo("정답");
-        assertThat(response.getContents().get(0).getWriter()).isEqualTo("파인애플");
+        assertThat(response.getStories()).hasSize(1);
+        assertThat(response.getStories().get(0).getContent()).isEqualTo("정답");
+        assertThat(response.getStories().get(0).getWriter()).isEqualTo("파인애플");
     }
 
     @Test
@@ -259,8 +259,8 @@ public class StoryServiceTest extends LoginTest {
         StoryPagingResponse response = storyService.findStoryByHeart(PageRequest.of(0, 4, Sort.by("start_date")));
 
         //then
-        assertThat(response.getContents()).hasSize(1);
-        assertThat(response.getContents().get(0).getContent()).isEqualTo("정답");
-        assertThat(response.getContents().get(0).getTitle()).isEqualTo("좋아요");
+        assertThat(response.getStories()).hasSize(1);
+        assertThat(response.getStories().get(0).getContent()).isEqualTo("정답");
+        assertThat(response.getStories().get(0).getTitle()).isEqualTo("좋아요");
     }
 }


### PR DESCRIPTION
Closes #104 

## 추가/수정한 기능 설명
- 무한 스크롤 구현 시 기존에 사용했던 cursor-based pagination 방식에서 **offset-based pagination** 방식으로 코드를 수정했습니다. (때문에 Slice 대신 Page를 이용하도록 수정했습니다)
- 성능테스트를 해본 결과 무한 스크롤 구현 시 offset-based pagination 방식의 성능이 아주 조금 더 좋게 나와 이 방법으로 리팩토링 했습니다. (cursor 방식이 생각보다 성능적으로 메리트가 있지 않음)

![image](https://github.com/TeamOwori/Owori-Server/assets/78026977/5ef50dbe-1e7c-4564-9c4d-9407eb8c2cf6)
Average(평균 응답 시간)는 미세하게 offset이 빠르고, Throughput에는 성능차이가 거의 같음

- 전체 조회 API/좋아요 누른 API/작성자별 조회 API/검색 API 모두 수정했습니다. 

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?