### PR TITLE
[FEAT] iOS 구글 로그인 관리

### DIFF
--- a/src/main/java/com/owori/domain/member/client/GoogleMemberClient.java
+++ b/src/main/java/com/owori/domain/member/client/GoogleMemberClient.java
@@ -15,21 +15,24 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.Collections;
+import java.util.Arrays;
 
 
 @Component
 public class GoogleMemberClient {
 
-    @Value("${social.google.client-id}")
-    private String clientId;
+    @Value("${social.google.android-client-id}")
+    private String androidClientId;
+
+    @Value("${social.google.ios-client-id}")
+    private String iosClientId;
 
     public GoogleMemberResponse requestToGoogle(final String token) {
         // idToken 무결성 확인
         HttpTransport transport = new NetHttpTransport();
         JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
         GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
-                .setAudience(Collections.singletonList(clientId))
+                .setAudience(Arrays.asList(androidClientId, iosClientId))
                 .build();
         GoogleIdToken idToken = null;
         try {
@@ -37,7 +40,6 @@ public class GoogleMemberClient {
         } catch (GeneralSecurityException | IOException e) {
             throw new InvalidTokenException();
         }
-
         Payload payload = idToken.getPayload();
 
         // 유저 식별자 받기 및 출력 테스트

--- a/src/main/java/com/owori/domain/member/controller/MemberController.java
+++ b/src/main/java/com/owori/domain/member/controller/MemberController.java
@@ -48,7 +48,7 @@ public class MemberController {
      * @return 멤버의 JwtToken 입니다.
      */
     @PostMapping("/google")
-        public ResponseEntity<MemberJwtResponse> saveMemberWithGoogle(@RequestBody @Valid MemberGoogleRequest memberGoogleRequest ) {
+    public ResponseEntity<MemberJwtResponse> saveMemberWithGoogle(@RequestBody @Valid MemberGoogleRequest memberGoogleRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(memberService.saveWithGoogleIfNone(memberGoogleRequest));
     }
 


### PR DESCRIPTION
Closes #120 

## 추가/수정한 기능 설명
ios의 구글 로그인 접근을 위해 client id를 추가했습니다. 

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?